### PR TITLE
fix(costs): use PopupFactory for alerts in CostDetailsListViewController

### DIFF
--- a/TrackMyCafe/View Layer/Flow/Costs/CostDetails/View/CostDetailsListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Costs/CostDetails/View/CostDetailsListViewController.swift
@@ -208,7 +208,10 @@ final class CostDetailsListViewController: UIViewController {
     let sumText = priceInputContainer.text
 
     guard viewModel.validate(name: name, sumText: sumText) else {
-      showValidationError()
+      PopupFactory.showPopup(
+        title: R.string.global.error(),
+        description: R.string.global.fillAllFields()
+      ) {}
       return
     }
 
@@ -228,7 +231,10 @@ final class CostDetailsListViewController: UIViewController {
         }
       } catch {
         await MainActor.run {
-          self.showErrorAlert(error)
+          PopupFactory.showPopup(
+            title: R.string.global.error(),
+            description: error.localizedDescription
+          ) {}
         }
       }
       await MainActor.run {
@@ -239,29 +245,6 @@ final class CostDetailsListViewController: UIViewController {
 
   @objc private func dismissKeyboard() {
     view.endEditing(true)
-  }
-
-  // Manual keyboard show/hide handling removed in favor of UIKeyboardLayoutGuide.
-
-  private func showValidationError() {
-    let alert = UIAlertController(
-      title: R.string.global.error(),
-      message: R.string.global.fillAllFields(),
-      preferredStyle: .alert
-    )
-
-    alert.addAction(UIAlertAction(title: R.string.global.actionOk(), style: .default))
-    present(alert, animated: true)
-  }
-
-  private func showErrorAlert(_ error: Error) {
-    let alert = UIAlertController(
-      title: R.string.global.error(),
-      message: error.localizedDescription,
-      preferredStyle: .alert
-    )
-    alert.addAction(UIAlertAction(title: R.string.global.actionOk(), style: .default))
-    present(alert, animated: true)
   }
 
   deinit {}
@@ -289,5 +272,4 @@ extension CostDetailsListViewController: UITextFieldDelegate {
     }
   }
 
-  // Numeric filtering moved into InputContainerView via enableNumericInput.
 }


### PR DESCRIPTION
Plan → Code → Expected outcome → Validation

Plan
- Unify alert presentation in CostDetailsListViewController with ProductDetailsViewController by using PopupFactory.
- Remove redundant helper methods and inline PopupFactory.showPopup in validation and error paths.

Code
- Updated TrackMyCafe/View Layer/Flow/Costs/CostDetails/View/CostDetailsListViewController.swift:
  - Inline calls:
    - On validation failure: PopupFactory.showPopup(title: R.string.global.error(), description: R.string.global.fillAllFields())
    - On save error: PopupFactory.showPopup(title: R.string.global.error(), description: error.localizedDescription)
  - Removed private methods: showValidationError(), showErrorAlert(_:)

Expected outcome
- Consistent UX across screens using PopupFactory; no behavior change aside from visual consistency.
- MVVM boundaries preserved; only VC code touched.

Validation
- Build should succeed; run on iPhone/iPad (iOS 15+). Test invalid input triggers PopupFactory; simulate save error shows error popup.

References
- Closes #91
- ProductDetailsViewController shows the expected PopupFactory usage.