### PR TITLE
feat(seed,ui,currency): add localized data seeding, currency display, and UI tweaks

### DIFF
--- a/TrackMyCafe/Extensions/UI/NumberFormatter+Extension.swift
+++ b/TrackMyCafe/Extensions/UI/NumberFormatter+Extension.swift
@@ -8,43 +8,49 @@
 import Foundation
 
 extension NumberFormatter {
-    
-    static var decimal: NumberFormatter {
-        let numberFormatter = NumberFormatter()
-        numberFormatter.numberStyle = .decimal
-        numberFormatter.minimumFractionDigits = 1
-        numberFormatter.groupingSeparator = ""
-        return numberFormatter
-    }
-    
-    static var currencyInteger: NumberFormatter {
-        let formater = NumberFormatter()
-        formater.numberStyle = .currency
-        formater.minimumFractionDigits = 2
-        formater.maximumFractionDigits = 2
-        formater.currencyDecimalSeparator = ","
-        formater.currencyGroupingSeparator = " "
-        formater.currencySymbol = RequestManager.shared.settings?.currencySymbol ?? DefaultValues.dollarSymbol
-        return formater
-    }
-    
-    static var percent: NumberFormatter {
-        let format = NumberFormatter()
-        format.numberStyle = .percent
-        format.maximumFractionDigits = 2
-        format.minimumFractionDigits = 0
-        format.groupingSize = 3
-        format.locale = Locale.autoupdatingCurrent
-        format.multiplier = 1
-        return format
-    }
-    
-    func string(_ value: Int) -> String {
-        return string(from: NSNumber(value: value))!
-    }
-    
-    func string(_ value: Double) -> String {
-        return string(from: NSNumber(value: value))!
-    }
-}
 
+  static var decimal: NumberFormatter {
+    let numberFormatter = NumberFormatter()
+    numberFormatter.numberStyle = .decimal
+    numberFormatter.minimumFractionDigits = 2
+    numberFormatter.maximumFractionDigits = 2
+    numberFormatter.groupingSeparator = ""
+    return numberFormatter
+  }
+
+  static var currencyInteger: NumberFormatter {
+    let formater = NumberFormatter()
+    formater.numberStyle = .currency
+    formater.minimumFractionDigits = 2
+    formater.maximumFractionDigits = 2
+    formater.currencyDecimalSeparator = ","
+    formater.currencyGroupingSeparator = " "
+    if let symbol = RequestManager.shared.settings?.currencySymbol {
+      formater.currencySymbol = symbol
+    } else {
+      let isUkrainian = Locale.current.languageCode == "uk"
+      formater.currencySymbol =
+        isUkrainian ? DefaultValues.currencySymbol : DefaultValues.dollarSymbol
+    }
+    return formater
+  }
+
+  static var percent: NumberFormatter {
+    let format = NumberFormatter()
+    format.numberStyle = .percent
+    format.maximumFractionDigits = 2
+    format.minimumFractionDigits = 0
+    format.groupingSize = 3
+    format.locale = Locale.autoupdatingCurrent
+    format.multiplier = 1
+    return format
+  }
+
+  func string(_ value: Int) -> String {
+    return string(from: NSNumber(value: value))!
+  }
+
+  func string(_ value: Double) -> String {
+    return string(from: NSNumber(value: value))!
+  }
+}

--- a/TrackMyCafe/Services/FIR/FirestoreDatabaseService.swift
+++ b/TrackMyCafe/Services/FIR/FirestoreDatabaseService.swift
@@ -476,8 +476,11 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
       FirebaseFields.avatarThumbnailUrl: "",
     ]
 
+    let isUkrainian = Locale.current.languageCode == "uk"
+    let defaultCurrencyName = isUkrainian ? DefaultValues.currencyName : DefaultValues.dollarName
+    let defaultCurrencySymbol = isUkrainian ? DefaultValues.currencySymbol : DefaultValues.dollarSymbol
     userValue["Settings"] = Settings(
-      currencyName: DefaultValues.dollarName, currencySymbol: DefaultValues.dollarSymbol
+      currencyName: defaultCurrencyName, currencySymbol: defaultCurrencySymbol
     ).forDatabase()
 
     return userValue

--- a/TrackMyCafe/View Layer/Flow/Costs/CostDetails/View/CostDetailsListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Costs/CostDetails/View/CostDetailsListViewController.swift
@@ -113,6 +113,9 @@ final class CostDetailsListViewController: UIViewController {
 
     priceInputContainer.setDelegate(self)
     priceInputContainer.enableNumericInput(maxFractionDigits: 2)
+    let currencySymbol = RequestManager.shared.settings?.currencySymbol
+      ?? ((Locale.current.languageCode == "uk") ? DefaultValues.currencySymbol : DefaultValues.dollarSymbol)
+    priceInputContainer.enableCurrencySuffix(symbol: currencySymbol)
     priceInputContainer.setReturnKeyType(.done)
 
     // Add containers to stack view

--- a/TrackMyCafe/View Layer/Flow/Costs/CostList/ViewModel/CostListItemViewModel.swift
+++ b/TrackMyCafe/View Layer/Flow/Costs/CostList/ViewModel/CostListItemViewModel.swift
@@ -21,9 +21,9 @@ class CostListItemViewModel: CostListItemViewModelType {
         return cost.name
     }
     
-    var costSum: String {
-        return cost.sum.description
-    }
+  var costSum: String {
+        return cost.sum.currency
+  }
     
     init(cost: CostModel) {
         self.cost = cost

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderDetailsViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderDetailsViewController.swift
@@ -144,7 +144,9 @@ class OrderDetailsViewController: UIViewController, UITextFieldDelegate {
     cashInputContainer.enableNumericInput(maxFractionDigits: 2)
     cardInputContainer.enableNumericInput(maxFractionDigits: 2)
     let currencySymbol =
-      RequestManager.shared.settings?.currencySymbol ?? DefaultValues.dollarSymbol
+      RequestManager.shared.settings?.currencySymbol
+      ?? ((Locale.current.languageCode == "uk")
+        ? DefaultValues.currencySymbol : DefaultValues.dollarSymbol)
     cashInputContainer.enableCurrencySuffix(symbol: currencySymbol)
     cardInputContainer.enableCurrencySuffix(symbol: currencySymbol)
     cashInputContainer.setReturnKeyType(.done)
@@ -193,10 +195,10 @@ class OrderDetailsViewController: UIViewController, UITextFieldDelegate {
     guard let viewModel = viewModel else { return }
 
     if viewModel.cash != 0 {
-      cashInputContainer.text = viewModel.cash.description
+      cashInputContainer.text = viewModel.cash.decimalFormat
     }
     if viewModel.card != 0 {
-      cardInputContainer.text = viewModel.card.description
+      cardInputContainer.text = viewModel.card.decimalFormat
     }
     if viewModel.sum != 0 {
       orderLabel.text = viewModel.sum.currency

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderList/View/Cells/SalesTableViewCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderList/View/Cells/SalesTableViewCell.swift
@@ -22,10 +22,7 @@ class OrdersTableViewCell: UITableViewCell {
 
   lazy var productsName = createOrdersLabel(
     text: "05.09.21", font: Typography.body, aligment: .left)
-  lazy var ordersSum = createOrdersLabel(text: "640", font: Typography.footnote, aligment: .right)
-  lazy var ordersLabel = createOrdersLabel(
-    text: R.string.global.plan(), font: Typography.footnote, aligment: .left)
-  lazy var cashSum = createOrdersLabel(text: "230", font: Typography.title3, aligment: .right)
+  lazy var ordersSum = createOrdersLabel(text: "640", font: Typography.body, aligment: .right)
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -47,7 +44,6 @@ class OrdersTableViewCell: UITableViewCell {
       guard let viewModel = viewModel else { return }
       productsName.text = viewModel.productsName
       ordersSum.text = viewModel.ordersSum
-      cashSum.text = viewModel.cashSum
     }
   }
 
@@ -78,8 +74,6 @@ class OrdersTableViewCell: UITableViewCell {
       productsName.centerYAnchor.constraint(equalTo: backgroundViewCell.centerYAnchor),
       productsName.leadingAnchor.constraint(
         equalTo: backgroundViewCell.leadingAnchor, constant: 16),
-      //productsName.widthAnchor.constraint(equalToConstant: 200),
-      productsName.heightAnchor.constraint(equalToConstant: 50),
     ])
 
     //        let cashStackView = UIStackView(arrangedSubviews: [cashLabel, cashSum],
@@ -87,31 +81,16 @@ class OrdersTableViewCell: UITableViewCell {
     //                                        spacing: 5,
     //                                        distribution: .fillEqually)
 
-    self.addSubview(cashSum)  // cashStackView
+    self.addSubview(ordersSum)
     NSLayoutConstraint.activate([
-      cashSum.topAnchor.constraint(equalTo: backgroundViewCell.topAnchor, constant: 15),
-      //            cashSum.leadingAnchor.constraint(equalTo: productsName.trailingAnchor, constant: 5),
-      //            cashSum.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -5),
-      //            cashSum.heightAnchor.constraint(equalToConstant: 25)
-      //            cashSum.centerYAnchor.constraint(equalTo: backgroundViewCell.centerYAnchor),
-      cashSum.trailingAnchor.constraint(equalTo: backgroundViewCell.trailingAnchor, constant: -30),
-      cashSum.heightAnchor.constraint(equalToConstant: 25),
+      ordersSum.centerYAnchor.constraint(equalTo: backgroundViewCell.centerYAnchor),
+      ordersSum.trailingAnchor.constraint(
+        equalTo: backgroundViewCell.trailingAnchor, constant: -16),
     ])
 
-    let ordersStackView = UIStackView(
-      arrangedSubviews: [ordersLabel, ordersSum],
-      axis: .horizontal,
-      spacing: 5,
-      distribution: .fillEqually)
-
-    self.addSubview(ordersStackView)
     NSLayoutConstraint.activate([
-      ordersStackView.bottomAnchor.constraint(
-        equalTo: backgroundViewCell.bottomAnchor, constant: 0),
-      //            ordersStackView.leadingAnchor.constraint(equalTo: productsName.trailingAnchor, constant: 5),
-      ordersStackView.trailingAnchor.constraint(
-        equalTo: backgroundViewCell.trailingAnchor, constant: -30),
-      ordersStackView.heightAnchor.constraint(equalToConstant: 25),
+      productsName.trailingAnchor.constraint(
+        lessThanOrEqualTo: ordersSum.leadingAnchor, constant: -12)
     ])
   }
 }

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderList/ViewModel/OrderListItemViewModel.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderList/ViewModel/OrderListItemViewModel.swift
@@ -16,7 +16,7 @@ class OrderListItemViewModel: OrderListItemViewModelType {
   }
 
   var ordersSum: String {
-    return String(Int(model.sum))
+    return model.sum.currency
   }
 
   var ordersLabel: String {
@@ -24,7 +24,7 @@ class OrderListItemViewModel: OrderListItemViewModelType {
   }
 
   var cashSum: String {
-    return String(Int(model.cash))
+    return model.cash.currency
   }
 
   var cashLabel: String {

--- a/TrackMyCafe/View Layer/Flow/Settings/Products/ProductDetail/View/ProductDetailsViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/Products/ProductDetail/View/ProductDetailsViewController.swift
@@ -97,6 +97,9 @@ class ProductDetailsViewController: UIViewController {
 
     priceInputContainer.setDelegate(self)
     priceInputContainer.enableNumericInput(maxFractionDigits: 2)
+    let currencySymbol = RequestManager.shared.settings?.currencySymbol
+      ?? ((Locale.current.languageCode == "uk") ? DefaultValues.currencySymbol : DefaultValues.dollarSymbol)
+    priceInputContainer.enableCurrencySuffix(symbol: currencySymbol)
     priceInputContainer.setReturnKeyType(.done)
 
     // Add containers to stack

--- a/TrackMyCafe/View Layer/Flow/Settings/Products/ProductList/View/Cells/ProductPriceTableViewCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/Products/ProductList/View/Cells/ProductPriceTableViewCell.swift
@@ -52,7 +52,7 @@ class ProductPriceTableViewCell: UITableViewCell {
 
   func configure(productPrice: ProductsPriceModel, indexPath: IndexPath) {
     productLabel.text = productPrice.name
-    quantityLabel.text = String(productPrice.price)
+    quantityLabel.text = productPrice.price.currency
 
     selectionStyle = .none
   }

--- a/TrackMyCafe/View Layer/Flow/Settings/SettingList/View/SettingListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/SettingList/View/SettingListViewController.swift
@@ -213,6 +213,43 @@ class SettingListViewController: UIViewController, UITableViewDelegate, UITableV
 
         ]))
 
+#if DEBUG
+#if targetEnvironment(simulator)
+    let devOptions: [SettingsOptionType] = [
+      .staticCell(
+        model: SettingsStaticOption(
+          title: "Seed Test Data",
+          icon: UIImage(systemName: SystemImages.gearshape),
+          iconBackgroundColor: .systemPurple
+        ) {
+          let alert = UIAlertController(
+            title: "Seed Test Data",
+            message: "Enter number of days",
+            preferredStyle: .alert
+          )
+          alert.addTextField { tf in
+            tf.keyboardType = .numberPad
+            tf.text = "14"
+          }
+          alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+          alert.addAction(UIAlertAction(title: "Seed", style: .default) { _ in
+            let daysText = alert.textFields?.first?.text ?? "14"
+            let days = Int(daysText) ?? 14
+            SVProgressHUD.show(withStatus: "Seeding data...")
+            Task {
+              await DomainDatabaseService.shared.seedTestData(forDays: days)
+                await SVProgressHUD.dismiss()
+              self.tableView.reloadData()
+            }
+          })
+          self.present(alert, animated: true)
+        })
+    ]
+
+    models.append(Section(title: "Developer", option: devOptions))
+#endif
+#endif
+
     // models.append(
     //   Section(
     //     title: "Database",

--- a/TrackMyCafe/View Layer/UI/Base/InputContainerView.swift
+++ b/TrackMyCafe/View Layer/UI/Base/InputContainerView.swift
@@ -195,6 +195,9 @@ final class InputContainerView: UIView {
     case .text(let keyboardType):
       containerView.addSubview(textField)
       textField.keyboardType = keyboardType
+      if keyboardType == .decimalPad || keyboardType == .numberPad {
+        textField.textAlignment = .right
+      }
       setupTextFieldConstraints()
 
     case .date(let mode):
@@ -340,13 +343,23 @@ final class InputContainerView: UIView {
     numericFilter = NumericTextInputFilter(maxFractionDigits: maxFractionDigits)
     if case .text = inputType {
       textField.keyboardType = .decimalPad
+      textField.textAlignment = .right
     }
   }
 
   // Show a currency symbol as a persistent suffix inside the text field
   func enableCurrencySuffix(symbol: String? = nil) {
     guard case .text = inputType else { return }
-    let currency = symbol ?? Locale.current.currencySymbol ?? "$"
+    let currency: String
+    if let symbol = symbol {
+      currency = symbol
+    } else {
+      let isUkrainian = Locale.current.languageCode == "uk"
+      currency =
+        isUkrainian
+        ? DefaultValues.currencySymbol
+        : (Locale.current.currencySymbol ?? DefaultValues.dollarSymbol)
+    }
     let label = UILabel()
     label.text = " \(currency)"
     label.font = Typography.title3


### PR DESCRIPTION
Plan → Code → Expected outcome → Validation

Plan
- Add debug-only seed UI in Settings (simulator, Debug only)
- Implement localized data seeding: income types (Hall default, Takeaway, Delivery), expanded product catalog, varied items/quantities, varied costs (rent, utilities, salary, etc.)
- Fix currency: use locale-based defaults and fallback; apply currency symbol across lists and inputs
- UI refinements: right-align numeric inputs; simplify Orders list cell layout (title left, sum right); enforce 2 fraction digits for cash/card inputs

Code (key changes)
- Domain seeding: TrackMyCafe/Services/Domain/DomainDatabaseService.swift: Added seedTestData(forDays:) with localized types/products, variable quantities and costs
- Debug UI: TrackMyCafe/View Layer/Flow/Settings/SettingList/View/SettingListViewController.swift: Added Developer section with "Seed Test Data" alert
- Currency defaults: TrackMyCafe/Services/FIR/FirestoreDatabaseService.swift: Locale-based Settings currency
- Currency formatter: TrackMyCafe/Extensions/UI/NumberFormatter+Extension.swift: Fallback to ₴ for uk, $ otherwise; 2 fraction digits
- Lists and inputs currency: 
  • Orders list vm: TrackMyCafe/View Layer/Flow/Orders/OrderList/ViewModel/OrderListItemViewModel.swift
  • Costs list vm: TrackMyCafe/View Layer/Flow/Costs/CostList/ViewModel/CostListItemViewModel.swift
  • Product price cell: TrackMyCafe/View Layer/Flow/Settings/Products/ProductList/View/Cells/ProductPriceTableViewCell.swift
  • Product details: TrackMyCafe/View Layer/Flow/Settings/Products/ProductDetail/View/ProductDetailsViewController.swift
  • Cost details: TrackMyCafe/View Layer/Flow/Costs/CostDetails/View/CostDetailsListViewController.swift
  • Order details: TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderDetailsViewController.swift
- Numeric alignment: TrackMyCafe/View Layer/UI/Base/InputContainerView.swift: Right-align numeric text fields
- Orders cell layout: TrackMyCafe/View Layer/Flow/Orders/OrderList/View/Cells/SalesTableViewCell.swift: Simplified to two labels

Expected outcome
- Seeding button appears only on simulator in Debug; generates realistic localized data for the selected days
- Currency shows correctly per device locale (₴ for uk, $ otherwise) across lists and inputs
- Order list cells show type left and sum right, avoiding overlap; numeric inputs right-aligned
- Cash/card fields display two fraction digits consistently

Validation
- Built locally; UI verified in simulator (uk locale) with seeded data
- Branch: feature/102-debug-simulator-data-seed → base: main
- Conventional commits included; ready for review