### PR TITLE
feat(localization): add recipe/app strings and localize Home header

### DIFF
--- a/TrackMyCafe/Resources/Localization/en.lproj/Global.strings
+++ b/TrackMyCafe/Resources/Localization/en.lproj/Global.strings
@@ -253,6 +253,16 @@
 "failedToSaveProductPrice" = "Failed to save product price";
 "enterPrice" = "Enter price";
 
+// Recipe & Ingredients
+"recipe" = "Recipe";
+"addIngredient" = "Add Ingredient";
+"selectIngredient" = "Select Ingredient";
+"enterQuantityPerUnit" = "Enter quantity per unit (%@)";
+"add" = "Add";
+
+// App
+"appName" = "TrackMyCafe";
+
 // MARK: - Good
 "goods" = "Goods";
 

--- a/TrackMyCafe/Resources/Localization/uk.lproj/Global.strings
+++ b/TrackMyCafe/Resources/Localization/uk.lproj/Global.strings
@@ -253,6 +253,16 @@
 "failedToSaveProductPrice" = "Не вдалося зберегти ціну товару";
 "enterPrice" = "Введіть ціну";
 
+// Recipe & Ingredients
+"recipe" = "Рецепт";
+"addIngredient" = "Додати інгредієнт";
+"selectIngredient" = "Виберіть інгредієнт";
+"enterQuantityPerUnit" = "Введіть кількість на одиницю (%@)";
+"add" = "Додати";
+
+// App
+"appName" = "TrackMyCafe";
+
 // MARK: - Good
 "goods" = "Товари";
 

--- a/TrackMyCafe/View Layer/Flow/Home/View/HomeHeaderView.swift
+++ b/TrackMyCafe/View Layer/Flow/Home/View/HomeHeaderView.swift
@@ -9,7 +9,7 @@ final class HomeHeaderView: UIView {
     let l = UILabel()
     l.applyDynamic(Typography.title2DemiBold)
     l.textColor = UIColor.Main.text
-    l.text = "TrackMyCafe"
+    l.text = R.string.global.appName()
     return l
   }()
 


### PR DESCRIPTION
Plan → Code → Expected outcome → Validation

Plan:
- Add localized keys for Recipe/Ingredient and app name in Global.strings (uk/en)
- Localize Home header title using R.string.global.appName()
- Keep existing string resource structure; no architecture changes

Code:
- Resources/Localization/en.lproj/Global.strings: add recipe/appName keys
- Resources/Localization/uk.lproj/Global.strings: add recipe/appName keys
- View Layer/Flow/Home/View/HomeHeaderView.swift: replace hardcoded "TrackMyCafe" with R.string.global.appName()

Expected outcome:
- App header displays localized app name
- String resources prepared for upcoming recipe UI localization

Validation:
- Build succeeds locally
- Switch App Language (Scheme → Run → Options) between English/Ukrainian; header reflects language