### PR TITLE
refactor(ui-cells): remove hardcoded default texts from table cells

### DIFF
--- a/TrackMyCafe/View Layer/Flow/Costs/CostDetails/View/Cells/DeletePurchaseDetailsTableViewCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Costs/CostDetails/View/Cells/DeletePurchaseDetailsTableViewCell.swift
@@ -20,7 +20,7 @@ class CostDetailsTableViewCell: UITableViewCell {
 
     let productLabel: UILabel = {
         let label = UILabel()
-        label.text = "Esspresso"
+        label.text = ""
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = UIColor.TableView.cellLabel
         label.applyDynamic(Typography.body)
@@ -30,7 +30,7 @@ class CostDetailsTableViewCell: UITableViewCell {
 
     let quantityLabel: UILabel = {
         let label = UILabel()
-        label.text = "0"
+        label.text = ""
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = UIColor.TableView.cellLabel
         label.applyDynamic(Typography.body)

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/Cells/OrderTableViewCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/Cells/OrderTableViewCell.swift
@@ -9,89 +9,91 @@ import UIKit
 
 class OrderTableViewCell: UITableViewCell {
 
-    let backgroundViewCell: UIView = {
-        let view = UIView()
-        view.backgroundColor = UIColor.TableView.cellBackground
-        view.layer.cornerRadius = 10
-        view.translatesAutoresizingMaskIntoConstraints = false
+  let backgroundViewCell: UIView = {
+    let view = UIView()
+    view.backgroundColor = UIColor.TableView.cellBackground
+    view.layer.cornerRadius = 10
+    view.translatesAutoresizingMaskIntoConstraints = false
 
-        return view
-    }()
+    return view
+  }()
 
-    let productLabel: UILabel = {
-        let label = UILabel()
-        label.text = "Esspresso"
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = UIColor.TableView.cellLabel
-        label.applyDynamic(Typography.body)
+  let productLabel: UILabel = {
+    let label = UILabel()
+    label.text = ""
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.textColor = UIColor.TableView.cellLabel
+    label.applyDynamic(Typography.body)
 
-        return label
-    }()
+    return label
+  }()
 
-    let quantityLabel: UILabel = {
-        let label = UILabel()
-        label.text = "0"
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = UIColor.TableView.cellLabel
-        label.applyDynamic(Typography.body)
-        
-        return label
-    }()
+  let quantityLabel: UILabel = {
+    let label = UILabel()
+    label.text = ""
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.textColor = UIColor.TableView.cellLabel
+    label.applyDynamic(Typography.body)
 
-    let productStepper: UIStepper = {
-        let stepper = UIStepper()
-        stepper.translatesAutoresizingMaskIntoConstraints = false
+    return label
+  }()
 
-        return stepper
-    }()
+  let productStepper: UIStepper = {
+    let stepper = UIStepper()
+    stepper.translatesAutoresizingMaskIntoConstraints = false
 
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    return stepper
+  }()
 
-        self.backgroundColor = UIColor.Main.background
-        setConstraints()
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+    self.backgroundColor = UIColor.Main.background
+    setConstraints()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  weak var viewModel: ProductListItemViewModelType? {
+    willSet(viewModel) {
+      guard let viewModel = viewModel else { return }
+      productLabel.text = viewModel.productLabel
+      quantityLabel.text = viewModel.quantityLabel
+      productStepper.value = viewModel.productStepperValue  //stepperValue
+      productStepper.tag = viewModel.productStepperTag  //indexPath.row
     }
+  }
 
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+  func setConstraints() {
 
-    weak var viewModel: ProductListItemViewModelType? {
-        willSet(viewModel) {
-            guard let viewModel = viewModel else { return }
-            productLabel.text = viewModel.productLabel
-            quantityLabel.text = viewModel.quantityLabel
-            productStepper.value = viewModel.productStepperValue //stepperValue
-            productStepper.tag = viewModel.productStepperTag //indexPath.row
-        }
-    }
-    
-    func setConstraints() {
+    self.addSubview(backgroundViewCell)
+    NSLayoutConstraint.activate([
+      backgroundViewCell.topAnchor.constraint(equalTo: self.topAnchor, constant: 0),
+      backgroundViewCell.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0),
+      backgroundViewCell.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 0),
+      backgroundViewCell.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -1),
+    ])
 
-        self.addSubview(backgroundViewCell)
-        NSLayoutConstraint.activate([
-            backgroundViewCell.topAnchor.constraint(equalTo: self.topAnchor, constant: 0),
-            backgroundViewCell.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0),
-            backgroundViewCell.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 0),
-            backgroundViewCell.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -1)
-        ])
+    self.addSubview(productLabel)
+    NSLayoutConstraint.activate([
+      productLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      productLabel.leadingAnchor.constraint(
+        equalTo: backgroundViewCell.leadingAnchor, constant: 15),
+    ])
 
-        self.addSubview(productLabel)
-        NSLayoutConstraint.activate([
-            productLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            productLabel.leadingAnchor.constraint(equalTo: backgroundViewCell.leadingAnchor, constant: 15)
-        ])
+    self.contentView.addSubview(productStepper)
+    NSLayoutConstraint.activate([
+      productStepper.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      productStepper.trailingAnchor.constraint(
+        equalTo: backgroundViewCell.trailingAnchor, constant: -20),
+    ])
 
-        self.contentView.addSubview(productStepper)
-        NSLayoutConstraint.activate([
-            productStepper.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            productStepper.trailingAnchor.constraint(equalTo: backgroundViewCell.trailingAnchor, constant: -20)
-        ])
-
-        self.contentView.addSubview(quantityLabel)
-        NSLayoutConstraint.activate([
-            quantityLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            quantityLabel.trailingAnchor.constraint(equalTo: productStepper.leadingAnchor, constant: -20)
-        ])
-    }
+    self.contentView.addSubview(quantityLabel)
+    NSLayoutConstraint.activate([
+      quantityLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      quantityLabel.trailingAnchor.constraint(equalTo: productStepper.leadingAnchor, constant: -20),
+    ])
+  }
 }

--- a/TrackMyCafe/View Layer/Flow/Settings/Products/ProductList/View/Cells/ProductPriceTableViewCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/Products/ProductList/View/Cells/ProductPriceTableViewCell.swift
@@ -20,7 +20,7 @@ class ProductPriceTableViewCell: UITableViewCell {
 
   let productLabel: UILabel = {
     let label = UILabel()
-    label.text = "Esspresso"
+    label.text = ""
     label.translatesAutoresizingMaskIntoConstraints = false
     label.textColor = UIColor.TableView.cellLabel
     label.applyDynamic(Typography.body)
@@ -30,7 +30,7 @@ class ProductPriceTableViewCell: UITableViewCell {
 
   let quantityLabel: UILabel = {
     let label = UILabel()
-    label.text = "0"
+    label.text = ""
     label.translatesAutoresizingMaskIntoConstraints = false
     label.textColor = UIColor.TableView.cellLabel
     label.applyDynamic(Typography.body)


### PR DESCRIPTION
Plan → Code → Expected outcome → Validation

Plan:
- Remove hardcoded placeholder texts from table cells to rely on model data

Code:
- ProductPriceTableViewCell: clear default label texts
- OrderTableViewCell: clear default label texts
- DeletePurchaseDetailsTableViewCell: clear default label texts

Expected outcome:
- Cells display values provided by view models/models; no misleading defaults

Validation:
- Build succeeds
- Open Products/Orders/Costs lists; all cells display real values