### PR TITLE
refactor(ui): replace Stevia with TinyConstraints in PersonTableViewCell

### DIFF
--- a/TrackMyCafe/View Layer/Flow/Persons/PersonList/View/Cell/PersonTableViewCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Persons/PersonList/View/Cell/PersonTableViewCell.swift
@@ -5,7 +5,7 @@
 //  Created by Леонід Квіт on 15.06.2024.
 //
 
-import Stevia
+import TinyConstraints
 import UIKit
 
 class PersonTableViewCell: UITableViewCell {
@@ -24,8 +24,6 @@ class PersonTableViewCell: UITableViewCell {
     view.contentMode = .scaleAspectFill
     view.layer.cornerRadius = 20
     view.clipsToBounds = true
-    view.size(40)
-
     return view
   }()
 
@@ -54,7 +52,6 @@ class PersonTableViewCell: UITableViewCell {
     button.addTarget(self, action: #selector(callAction(_:)), for: .touchUpInside)
     button.layer.cornerRadius = 15
     button.clipsToBounds = true
-    button.size(30)
     return button
   }()
 
@@ -85,14 +82,21 @@ class PersonTableViewCell: UITableViewCell {
     vStack.axis = .vertical
     vStack.spacing = UIConstants.smallSpacing
 
-    let hStack = UIStackView(arrangedSubviews: [profileImage.wrapV(), vStack, callButton.wrapV()])
+    let hStack = UIStackView(arrangedSubviews: [profileImage, vStack, callButton])
     hStack.axis = .horizontal
     hStack.spacing = UIConstants.standardSpacing
+    hStack.alignment = .center
 
     contentView.addSubview(hStack)
-    hStack.horizontalToSuperview(
-      insets: .init(
-        top: 0, left: UIConstants.standardPadding, bottom: 0, right: UIConstants.standardPadding))
+    
+    // Constraints
+    profileImage.height(40)
+    profileImage.width(40)
+    
+    callButton.height(30)
+    callButton.width(30)
+    
+    hStack.edgesToSuperview(excluding: .vertical, insets: .init(top: 0, left: UIConstants.standardPadding, bottom: 0, right: UIConstants.standardPadding))
     hStack.centerInSuperview()
   }
 


### PR DESCRIPTION
Plan → Code → Expected outcome → Validation

Plan:
- Remove Stevia dependency from PersonTableViewCell.swift
- Replace Stevia syntax with TinyConstraints (already present in project) and standard UIKit
- Remove `import Stevia` to avoid compilation errors on iOS 15+

Code:
- PersonTableViewCell.swift:
  - Remove `import Stevia`, add `import TinyConstraints`
  - Replace `view.size(40)`/`wrapV()` with `height(40)/width(40)` and `UIStackView` alignment
  - Use `edgesToSuperview` and `centerInSuperview` for layout

Expected outcome:
- Code compiles without Stevia errors (e.g. `alignCenter` ambiguity)
- Layout remains identical (image + text stack + button, centered horizontally)

Validation:
- Build succeeds
- Person list cell layout appears correct on simulator