### PR TITLE
feat(home): add cash and card balances to dashboard

### DIFF
--- a/TrackMyCafe/View Layer/Flow/Home/View/HomeHeaderView.swift
+++ b/TrackMyCafe/View Layer/Flow/Home/View/HomeHeaderView.swift
@@ -4,6 +4,7 @@ import UIKit
 final class HomeHeaderView: UIView {
     var onAddIncome: (() -> Void)?
     var onAddExpense: (() -> Void)?
+    var onPeriodChanged: ((Int) -> Void)?
 
     private let titleLabel: UILabel = {
         let l = UILabel()
@@ -34,6 +35,7 @@ final class HomeHeaderView: UIView {
         isEditable: false
     )
     private let profitCard = ProfitCard()
+    private let balanceCard = BalanceCard()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -46,7 +48,14 @@ final class HomeHeaderView: UIView {
     }
 
     func configure(
-        date: Date, today: Double, week: Double, month: Double, expenses: Double, profit: Double
+        date: Date,
+        today: Double,
+        week: Double,
+        month: Double,
+        expenses: Double,
+        profit: Double,
+        cash: Double,
+        card: Double
     ) {
         dateLabel.text = DateFormatter.appFullDate.string(from: date)
 
@@ -54,6 +63,10 @@ final class HomeHeaderView: UIView {
         weekContainer.text = NumberFormatter.currencyInteger.string(week)
         monthContainer.text = NumberFormatter.currencyInteger.string(month)
         profitCard.configure(expenses: expenses, profit: profit)
+        balanceCard.configure(
+            cash: NumberFormatter.currencyInteger.string(cash),
+            card: NumberFormatter.currencyInteger.string(card)
+        )
     }
 
     private func setupUI() {
@@ -94,9 +107,9 @@ final class HomeHeaderView: UIView {
         miniStack.spacing = UIConstants.standardPadding
         miniStack.distribution = UIStackView.Distribution.fillEqually
 
-        let contentStack = UIStackView(arrangedSubviews: [
-            headerStack, actionsStack, todayCard, miniStack, profitCard,
-        ])
+        let contentStack = UIStackView(
+            arrangedSubviews: [headerStack, actionsStack, todayCard, miniStack, balanceCard, profitCard]
+        )
         contentStack.axis = NSLayoutConstraint.Axis.vertical
         contentStack.spacing = UIConstants.largeSpacing
 
@@ -244,3 +257,68 @@ private final class TodayCardView: UIView {
 }
 
 // MARK: - Localization helper
+
+private final class BalanceCard: UIView {
+    private let iconCash = UIImageView()
+    private let iconCard = UIImageView()
+    private let cashLabel = UILabel()
+    private let cashValue = UILabel()
+    private let cardLabel = UILabel()
+    private let cardValue = UILabel()
+
+    init() {
+        super.init(frame: .zero)
+        backgroundColor = UIColor.TableView.cellBackground
+        layer.cornerRadius = UIConstants.extraLargeCornerRadius
+
+        iconCash.image = UIImage(systemName: SystemImages.banknoteFill)
+        iconCash.tintColor = UIColor.systemGreen
+        iconCash.contentMode = .scaleAspectFit
+        iconCard.image = UIImage(systemName: SystemImages.creditCardCircleFill)
+        iconCard.tintColor = UIColor.systemBlue
+        iconCard.contentMode = .scaleAspectFit
+
+        cashLabel.applyDynamic(Typography.footnote)
+        cashLabel.textColor = UIColor.Main.text.alpha(0.7)
+        cashLabel.text = R.string.global.receivedInCash()
+        cardLabel.applyDynamic(Typography.footnote)
+        cardLabel.textColor = UIColor.Main.text.alpha(0.7)
+        cardLabel.text = R.string.global.receivedByCard()
+
+        cashValue.applyDynamic(Typography.title3DemiBold)
+        cashValue.textColor = UIColor.Main.text
+        cardValue.applyDynamic(Typography.title3DemiBold)
+        cardValue.textColor = UIColor.Main.text
+
+        let cashRow = UIStackView(arrangedSubviews: [iconCash, cashLabel, UIView(), cashValue])
+        cashRow.axis = .horizontal
+        cashRow.spacing = UIConstants.smallSpacing
+        iconCash.size(CGSize(width: UIConstants.iconContainerSize, height: UIConstants.iconContainerSize))
+
+        let cardRow = UIStackView(arrangedSubviews: [iconCard, cardLabel, UIView(), cardValue])
+        cardRow.axis = .horizontal
+        cardRow.spacing = UIConstants.smallSpacing
+        iconCard.size(CGSize(width: UIConstants.iconContainerSize, height: UIConstants.iconContainerSize))
+
+        let stack = UIStackView(arrangedSubviews: [cashRow, cardRow])
+        stack.axis = .vertical
+        stack.spacing = UIConstants.standardSpacing
+
+        addSubview(stack)
+        stack.edgesToSuperview(
+            insets: .init(
+                top: UIConstants.standardPadding,
+                left: UIConstants.standardPadding,
+                bottom: UIConstants.standardPadding,
+                right: UIConstants.standardPadding
+            )
+        )
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func configure(cash: String, card: String) {
+        cashValue.text = cash
+        cardValue.text = card
+    }
+}

--- a/TrackMyCafe/View Layer/Flow/Home/View/HomeViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Home/View/HomeViewController.swift
@@ -75,7 +75,9 @@ final class HomeViewController: UIViewController {
       week: viewModel.weekSum,
       month: viewModel.monthSum,
       expenses: viewModel.monthExpenses,
-      profit: viewModel.monthProfit
+      profit: viewModel.monthProfit,
+      cash: viewModel.cashBalance,
+      card: viewModel.cardBalance
     )
     setTableHeaderSized()
     tableView.reloadData()

--- a/TrackMyCafe/View Layer/Flow/Home/ViewModel/HomeViewModel.swift
+++ b/TrackMyCafe/View Layer/Flow/Home/ViewModel/HomeViewModel.swift
@@ -7,6 +7,8 @@ final class HomeViewModel: HomeViewModelType {
   private(set) var monthExpenses: Double = 0
   private(set) var monthProfit: Double = 0
   private(set) var dateToday: Date = Date()
+  private(set) var cashBalance: Double = 0
+  private(set) var cardBalance: Double = 0
 
   private(set) var lastIncome: [OrderModel] = []
   private(set) var lastExpense: [OpexExpenseModel] = []
@@ -29,6 +31,7 @@ final class HomeViewModel: HomeViewModelType {
 
     computeIncomeMetrics(from: orders)
     computeExpenseMetrics(from: costs)
+    computeBalances(from: orders)
     computeLists(orders: orders, costs: costs)
   }
   
@@ -52,9 +55,13 @@ final class HomeViewModel: HomeViewModelType {
     monthProfit = monthSum - monthExpenses
   }
 
+  private func computeBalances(from orders: [OrderModel]) {
+    cashBalance = orders.reduce(0) { $0 + $1.cash }
+    cardBalance = orders.reduce(0) { $0 + $1.card }
+  }
+
   private func computeLists(orders: [OrderModel], costs: [OpexExpenseModel]) {
     lastIncome = orders.sorted { $0.date > $1.date }.prefix(3).map { $0 }
     lastExpense = costs.sorted { $0.date > $1.date }.prefix(3).map { $0 }
   }
 }
-

--- a/TrackMyCafe/View Layer/Flow/Home/ViewModel/HomeViewModelType.swift
+++ b/TrackMyCafe/View Layer/Flow/Home/ViewModel/HomeViewModelType.swift
@@ -1,17 +1,18 @@
 import Foundation
 
 protocol HomeViewModelType {
-  var todaySum: Double { get }
-  var weekSum: Double { get }
-  var monthSum: Double { get }
-  var monthExpenses: Double { get }
-  var monthProfit: Double { get }
-  var dateToday: Date { get }
+    var todaySum: Double { get }
+    var weekSum: Double { get }
+    var monthSum: Double { get }
+    var monthExpenses: Double { get }
+    var monthProfit: Double { get }
+    var dateToday: Date { get }
+    var cashBalance: Double { get }
+    var cardBalance: Double { get }
 
-  var lastIncome: [OrderModel] { get }
-  var lastExpense: [OpexExpenseModel] { get }
+    var lastIncome: [OrderModel] { get }
+    var lastExpense: [OpexExpenseModel] { get }
 
-  @MainActor
-  func loadDashboard() async
+    @MainActor
+    func loadDashboard() async
 }
-


### PR DESCRIPTION
Plan → Code → Expected outcome → Validation

Plan
- Add cash/card balances to Home dashboard based on existing Orders data.
- Keep implementation lightweight for v1.0.0 (no full FinanceService/ledger yet).
- Reuse existing HomeViewModel/HomeHeaderView and aggregation logic.

Code
- HomeViewModelType/HomeViewModel
  - Added `cashBalance` and `cardBalance` properties.
  - `loadDashboard()` now calls `computeBalances(from:)` in addition to existing aggregation methods.
  - `computeBalances(from:)` calculates balances as Σ order.cash / Σ order.card over all orders.
- HomeHeaderView
  - Extended `configure` to accept `cash` and `card` values.
  - Added `BalanceCard` UI block showing Cash and Card balances with icons and localized labels.
  - Inserted `BalanceCard` into the main header stack between period mini-cards and profit card.
- HomeViewController
  - Updated `headerView.configure` call to pass `viewModel.cashBalance` and `viewModel.cardBalance`.

Behavior
- Cash/Card balances are derived only from Orders (payments), consistent with v1.0.0 scope.
- Opex currently does not have a payment method, so expenses do not change cash/card balances yet.
- Existing metrics (today/week/month sales, monthly expenses and profit, recent incomes/expenses) remain unchanged.

Validation
- Manual: create several orders with different cash/card splits and verify:
  - Cash balance equals the sum of all order.cash values.
  - Card balance equals the sum of all order.card values.
- Manual: verify that Today/Week/Month, Expenses, Profit and recent transactions still display correctly.
- Regression: open Sales, Costs, Settings flows to ensure no navigation regressions.

References
- Closes #133
- Follow-up idea (already tracked as issue #147): move to journal-based cash/card accounting with daily balances for v1.1.0+.
