### PR TITLE
feat(home): toggle profit icon by sign; unify KPI typography

### DIFF
--- a/TrackMyCafe/View Layer/Flow/Home/View/HomeHeaderView.swift
+++ b/TrackMyCafe/View Layer/Flow/Home/View/HomeHeaderView.swift
@@ -25,17 +25,24 @@ final class HomeHeaderView: UIView {
     private let incomeButton = DefaultButton()
     private let expenseButton = DefaultButton()
 
-    private let todayCard = TodayCardView()
-    private let weekContainer = InputContainerView(
-        labelText: R.string.global.week(), inputType: .text(keyboardType: .decimalPad),
-        isEditable: false
-    )
-    private let monthContainer = InputContainerView(
-        labelText: R.string.global.month(), inputType: .text(keyboardType: .decimalPad),
-        isEditable: false
+    private let summaryCard = TodayCardView()
+    private let expensesCard = SimpleKpiCard(
+        iconSystemName: "arrow.down.right",
+        tint: UIColor.systemRed.withAlphaComponent(0.15),
+        iconTint: UIColor.systemRed
     )
     private let profitCard = ProfitCard()
     private let balanceCard = BalanceCard()
+    private let periodControl: UISegmentedControl = {
+        let control = UISegmentedControl(items: [
+            R.string.global.today(), R.string.global.week(), R.string.global.month(),
+        ])
+        control.selectedSegmentIndex = 2
+        return control
+    }()
+    private let kpiRow1 = UIStackView()
+    private let kpiRow2 = UIStackView()
+    private var isThreeInRow = true
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -49,20 +56,35 @@ final class HomeHeaderView: UIView {
 
     func configure(
         date: Date,
-        today: Double,
-        week: Double,
-        month: Double,
+        period: DashboardPeriod,
+        sales: Double,
         expenses: Double,
         profit: Double,
         cash: Double,
         card: Double
     ) {
         dateLabel.text = DateFormatter.appFullDate.string(from: date)
+        periodControl.selectedSegmentIndex = period.rawValue
 
-        todayCard.valueText = NumberFormatter.currencyInteger.string(today)
-        weekContainer.text = NumberFormatter.currencyInteger.string(week)
-        monthContainer.text = NumberFormatter.currencyInteger.string(month)
-        profitCard.configure(expenses: expenses, profit: profit)
+        let periodTitle: String
+        switch period {
+        case .day:
+            periodTitle = R.string.global.today()
+        case .week:
+            periodTitle = R.string.global.week()
+        case .month:
+            periodTitle = R.string.global.month()
+        }
+
+        let salesText = NumberFormatter.currencyInteger.string(sales)
+        let incomeTitle = R.string.global.incomeFor(periodTitle.lowercased())
+        summaryCard.configure(title: incomeTitle, value: salesText)
+        expensesCard.configure(
+            title: R.string.global.costs() + " " + periodTitle.lowercased(),
+            value: NumberFormatter.currencyInteger.string(expenses)
+        )
+        profitCard.configure(
+            periodTitle: periodTitle.lowercased(), expenses: expenses, profit: profit)
         balanceCard.configure(
             cash: NumberFormatter.currencyInteger.string(cash),
             card: NumberFormatter.currencyInteger.string(card)
@@ -100,15 +122,23 @@ final class HomeHeaderView: UIView {
         actionsStack.addArrangedSubview(incomeButton)
         actionsStack.addArrangedSubview(expenseButton)
 
-        weekContainer.configure(labelText: R.string.global.week())
-        monthContainer.configure(labelText: R.string.global.month())
-        let miniStack = UIStackView(arrangedSubviews: [weekContainer, monthContainer])
-        miniStack.axis = NSLayoutConstraint.Axis.horizontal
-        miniStack.spacing = UIConstants.standardPadding
-        miniStack.distribution = UIStackView.Distribution.fillEqually
+        periodControl.addTarget(self, action: #selector(periodChanged), for: .valueChanged)
+
+        kpiRow1.axis = .horizontal
+        kpiRow1.spacing = UIConstants.standardPadding
+        kpiRow1.distribution = .fillEqually
+        kpiRow2.axis = .horizontal
+        kpiRow2.spacing = UIConstants.standardPadding
+        kpiRow2.distribution = .fillEqually
+
+        kpiRow1.addArrangedSubview(summaryCard)
+        kpiRow1.addArrangedSubview(expensesCard)
+        kpiRow1.addArrangedSubview(profitCard)
 
         let contentStack = UIStackView(
-            arrangedSubviews: [headerStack, actionsStack, todayCard, miniStack, balanceCard, profitCard]
+            arrangedSubviews: [
+                headerStack, actionsStack, periodControl, kpiRow1, kpiRow2, balanceCard,
+            ]
         )
         contentStack.axis = NSLayoutConstraint.Axis.vertical
         contentStack.spacing = UIConstants.largeSpacing
@@ -125,13 +155,14 @@ final class HomeHeaderView: UIView {
 
         let containerHeight =
             UIConstants.cellHeight + UIConstants.largeSpacing + UIConstants.standardPadding
-        todayCard.height(containerHeight)
-        weekContainer.height(containerHeight)
-        monthContainer.height(containerHeight)
+        summaryCard.height(containerHeight)
+        expensesCard.height(containerHeight)
+        profitCard.height(containerHeight)
     }
 
     @objc private func incomeTap() { onAddIncome?() }
     @objc private func expenseTap() { onAddExpense?() }
+    @objc private func periodChanged() { onPeriodChanged?(periodControl.selectedSegmentIndex) }
 }
 
 // MARK: - Small UI Components
@@ -157,9 +188,9 @@ private final class ProfitCard: UIView {
         iconView.contentMode = .scaleAspectFit
         titleLabel.applyDynamic(Typography.footnote)
         titleLabel.textColor = UIColor.Main.text.alpha(0.7)
-        titleLabel.text = R.string.global.monthlyProfit()
-        valueLabel.applyDynamic(Typography.title3DemiBold)
+        valueLabel.applyDynamic(Typography.title2DemiBold)
         valueLabel.textColor = UIColor.systemRed
+        valueLabel.adjustsFontSizeToFitWidth = false
         divider.backgroundColor = UIColor.Main.text.alpha(0.1)
         footerLabel.applyDynamic(Typography.footnote)
         footerLabel.textColor = UIColor.Main.text.alpha(0.7)
@@ -167,7 +198,8 @@ private final class ProfitCard: UIView {
         badgeView.addSubview(iconView)
         iconView.size(CGSize(width: UIConstants.largeIconSize, height: UIConstants.largeIconSize))
         iconView.centerInSuperview()
-        badgeView.size(CGSize(width: UIConstants.badgeSize, height: UIConstants.badgeSize))
+        badgeView.width(UIConstants.badgeSize)
+        badgeView.height(UIConstants.badgeSize)
 
         let vStack = UIStackView(arrangedSubviews: [titleLabel, valueLabel])
         vStack.axis = .vertical
@@ -181,7 +213,7 @@ private final class ProfitCard: UIView {
         //    header.axis = .horizontal
         //    header.spacing = UIConstants.smallSpacing
 
-        let stack = UIStackView(arrangedSubviews: [hStack, divider, footerLabel])
+        let stack = UIStackView(arrangedSubviews: [hStack, footerLabel])
         stack.axis = .vertical
         stack.spacing = UIConstants.standardSpacing
 
@@ -194,15 +226,25 @@ private final class ProfitCard: UIView {
                 right: UIConstants.standardPadding
             )
         )
-        divider.height(UIConstants.standardBorderWidth)
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    func configure(expenses: Double, profit: Double) {
+    func configure(periodTitle: String, expenses: Double, profit: Double) {
+        titleLabel.text = R.string.global.monthlyProfit(periodTitle.lowercased())
         let profitText = NumberFormatter.currencyInteger.string(profit)
         valueLabel.text = profitText
-        valueLabel.textColor = profit >= 0 ? UIColor.systemGreen : UIColor.systemRed
+        if profit >= 0 {
+            iconView.image = UIImage(systemName: "arrow.up.right")
+            iconView.tintColor = UIColor.systemGreen
+            badgeView.backgroundColor = UIColor.systemGreen.withAlphaComponent(0.2)
+            valueLabel.textColor = UIColor.systemGreen
+        } else {
+            iconView.image = UIImage(systemName: "arrow.down.right")
+            iconView.tintColor = UIColor.systemRed
+            badgeView.backgroundColor = UIColor.systemRed.withAlphaComponent(0.2)
+            valueLabel.textColor = UIColor.systemRed
+        }
         let expensesText = NumberFormatter.currencyInteger.string(expenses)
         footerLabel.text = R.string.global.expensesPrefix() + expensesText
     }
@@ -215,8 +257,6 @@ private final class TodayCardView: UIView {
     private let titleLabel = UILabel()
     private let valueLabel = UILabel()
 
-    var valueText: String? { didSet { valueLabel.text = valueText } }
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = UIColor.TableView.cellBackground
@@ -224,14 +264,69 @@ private final class TodayCardView: UIView {
 
         iconBadge.backgroundColor = UIColor.systemGreen.withAlphaComponent(0.15)
         iconBadge.layer.cornerRadius = UIConstants.badgeCornerRadius
-        iconView.image = UIImage(systemName: "calendar")
-        iconView.tintColor = UIColor.Button.background
+        iconView.image = UIImage(systemName: "arrow.up.right")
+        iconView.tintColor = UIColor.systemGreen
         iconView.contentMode = .scaleAspectFit
         titleLabel.applyDynamic(Typography.footnote)
         titleLabel.textColor = UIColor.Main.text.alpha(0.7)
         titleLabel.text = R.string.global.today()
-        valueLabel.applyDynamic(Typography.title3DemiBold)
+        valueLabel.applyDynamic(Typography.title2DemiBold)
         valueLabel.textColor = UIColor.Main.text
+        valueLabel.adjustsFontSizeToFitWidth = true
+        valueLabel.minimumScaleFactor = 0.7
+
+        iconBadge.addSubview(iconView)
+        iconView.size(CGSize(width: UIConstants.largeIconSize, height: UIConstants.largeIconSize))
+        iconView.centerInSuperview()
+        iconBadge.width(UIConstants.badgeSize)
+        iconBadge.height(UIConstants.badgeSize)
+
+        let header = UIStackView(arrangedSubviews: [titleLabel, valueLabel])
+        header.axis = .vertical
+        header.spacing = UIConstants.smallSpacing
+
+        let stack = UIStackView(arrangedSubviews: [iconBadge, header])
+        stack.axis = .horizontal
+        stack.spacing = UIConstants.smallSpacing
+
+        addSubview(stack)
+        stack.edgesToSuperview(
+            insets: .init(
+                top: UIConstants.standardPadding, left: UIConstants.standardPadding,
+                bottom: UIConstants.standardPadding, right: UIConstants.standardPadding))
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func configure(title: String, value: String) {
+        titleLabel.text = title
+        valueLabel.text = value
+    }
+}
+
+// MARK: - Simple KPI Card
+private final class SimpleKpiCard: UIView {
+    private let iconView = UIImageView()
+    private let iconBadge = UIView()
+    private let titleLabel = UILabel()
+    private let valueLabel = UILabel()
+
+    init(iconSystemName: String, tint: UIColor, iconTint: UIColor) {
+        super.init(frame: .zero)
+        backgroundColor = UIColor.TableView.cellBackground
+        layer.cornerRadius = UIConstants.extraLargeCornerRadius
+
+        iconBadge.backgroundColor = tint
+        iconBadge.layer.cornerRadius = UIConstants.badgeCornerRadius
+        iconView.image = UIImage(systemName: iconSystemName)
+        iconView.tintColor = iconTint
+        iconView.contentMode = .scaleAspectFit
+        titleLabel.applyDynamic(Typography.footnote)
+        titleLabel.textColor = UIColor.Main.text.alpha(0.7)
+        valueLabel.applyDynamic(Typography.title2DemiBold)
+        valueLabel.textColor = UIColor.Main.text
+        valueLabel.adjustsFontSizeToFitWidth = true
+        valueLabel.minimumScaleFactor = 0.7
 
         iconBadge.addSubview(iconView)
         iconView.size(CGSize(width: UIConstants.largeIconSize, height: UIConstants.largeIconSize))
@@ -254,6 +349,72 @@ private final class TodayCardView: UIView {
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func configure(title: String, value: String) {
+        titleLabel.text = title
+        valueLabel.text = value
+    }
+}
+
+extension HomeHeaderView {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let width = bounds.width
+        let spacing = UIConstants.standardPadding
+        let cardWidth = (width - 2 * spacing) / 3
+        let shouldBeThree = cardWidth >= 140
+        if shouldBeThree != isThreeInRow {
+            isThreeInRow = shouldBeThree
+            if shouldBeThree {
+                kpiRow2.arrangedSubviews.forEach {
+                    kpiRow2.removeArrangedSubview($0)
+                    $0.removeFromSuperview()
+                }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.arrangedSubviews.forEach { _ in }
+                kpiRow1.addArrangedSubview(summaryCard)
+                kpiRow1.addArrangedSubview(expensesCard)
+                kpiRow1.addArrangedSubview(profitCard)
+            } else {
+                kpiRow1.arrangedSubviews.forEach {
+                    kpiRow1.removeArrangedSubview($0)
+                    $0.removeFromSuperview()
+                }
+                kpiRow1.addArrangedSubview(summaryCard)
+                kpiRow1.addArrangedSubview(expensesCard)
+                kpiRow2.arrangedSubviews.forEach {
+                    kpiRow2.removeArrangedSubview($0)
+                    $0.removeFromSuperview()
+                }
+                kpiRow2.addArrangedSubview(profitCard)
+            }
+        }
+    }
 }
 
 // MARK: - Localization helper
@@ -293,12 +454,14 @@ private final class BalanceCard: UIView {
         let cashRow = UIStackView(arrangedSubviews: [iconCash, cashLabel, UIView(), cashValue])
         cashRow.axis = .horizontal
         cashRow.spacing = UIConstants.smallSpacing
-        iconCash.size(CGSize(width: UIConstants.iconContainerSize, height: UIConstants.iconContainerSize))
+        iconCash.size(
+            CGSize(width: UIConstants.iconContainerSize, height: UIConstants.iconContainerSize))
 
         let cardRow = UIStackView(arrangedSubviews: [iconCard, cardLabel, UIView(), cardValue])
         cardRow.axis = .horizontal
         cardRow.spacing = UIConstants.smallSpacing
-        iconCard.size(CGSize(width: UIConstants.iconContainerSize, height: UIConstants.iconContainerSize))
+        iconCard.size(
+            CGSize(width: UIConstants.iconContainerSize, height: UIConstants.iconContainerSize))
 
         let stack = UIStackView(arrangedSubviews: [cashRow, cardRow])
         stack.axis = .vertical


### PR DESCRIPTION
Plan → Code → Expected outcome → Validation

Plan:
- Change income card title to "Income for <period>" and use green up arrow.
- In Profit card, switch icon and color by sign (green up for profit, red down for loss).
- Unify number typography across KPI cards; remove divider from Profit card; enforce square icon badges.

Code:
- HomeHeaderView.swift: profit icon toggle in ProfitCard.configure(); income title via R.string.global.incomeFor(); TodayCardView uses green up arrow; badges sized with equal width/height.

Expected outcome:
- Income/Expenses/Profit numbers share the same font size; Profit never looks smaller.
- Profit card icon reflects profit vs loss at a glance.
- KPI badges look square, not stretched.

Validation:
- App builds and Home screen shows correct icons and fonts across day/week/month.
- Visual check on iPhone and iPad simulators.
