### PR TITLE
Fix demo data deletion and navigation bar glitches

### DIFF
--- a/R.generated.swift
+++ b/R.generated.swift
@@ -218,7 +218,7 @@ struct _R {
       var useBioAuth: RswiftResources.StringResource1<String> { .init(key: "useBioAuth", tableName: "Auth", source: source, developmentValue: "Use %@ for quick authorization", comment: nil) }
     }
 
-    /// This `_R.string.global` struct is generated, and contains static references to 318 localization keys.
+    /// This `_R.string.global` struct is generated, and contains static references to 325 localization keys.
     struct global {
       let source: RswiftResources.StringResource.Source
 
@@ -648,6 +648,48 @@ struct _R {
       ///
       /// Locales: en, uk
       var delete: RswiftResources.StringResource { .init(key: "delete", tableName: "Global", source: source, developmentValue: "Delete", comment: nil) }
+
+      /// en translation: Delete Demo Data
+      ///
+      /// Key: deleteDemoData
+      ///
+      /// Locales: en, uk
+      var deleteDemoData: RswiftResources.StringResource { .init(key: "deleteDemoData", tableName: "Global", source: source, developmentValue: "Delete Demo Data", comment: nil) }
+
+      /// en translation: This will remove all demo data but keep your personal entries.
+      ///
+      /// Key: deleteDemoDataMessage
+      ///
+      /// Locales: en, uk
+      var deleteDemoDataMessage: RswiftResources.StringResource { .init(key: "deleteDemoDataMessage", tableName: "Global", source: source, developmentValue: "This will remove all demo data but keep your personal entries.", comment: nil) }
+
+      /// en translation: Delete Demo Data?
+      ///
+      /// Key: deleteDemoDataTitle
+      ///
+      /// Locales: en, uk
+      var deleteDemoDataTitle: RswiftResources.StringResource { .init(key: "deleteDemoDataTitle", tableName: "Global", source: source, developmentValue: "Delete Demo Data?", comment: nil) }
+
+      /// en translation: Deleting...
+      ///
+      /// Key: deleting
+      ///
+      /// Locales: en, uk
+      var deleting: RswiftResources.StringResource { .init(key: "deleting", tableName: "Global", source: source, developmentValue: "Deleting...", comment: nil) }
+
+      /// en translation: Would you like to fill the app with demo data to see how it works?
+      ///
+      /// Key: demoDataMessage
+      ///
+      /// Locales: en, uk
+      var demoDataMessage: RswiftResources.StringResource { .init(key: "demoDataMessage", tableName: "Global", source: source, developmentValue: "Would you like to fill the app with demo data to see how it works?", comment: nil) }
+
+      /// en translation: Demo Data
+      ///
+      /// Key: demoDataTitle
+      ///
+      /// Locales: en, uk
+      var demoDataTitle: RswiftResources.StringResource { .init(key: "demoDataTitle", tableName: "Global", source: source, developmentValue: "Demo Data", comment: nil) }
 
       /// en translation: Developer
       ///
@@ -1628,6 +1670,13 @@ struct _R {
       ///
       /// Locales: en, uk
       var pleaseSelectIngredient: RswiftResources.StringResource { .init(key: "pleaseSelectIngredient", tableName: "Global", source: source, developmentValue: "Please select an ingredient", comment: nil) }
+
+      /// en translation: Preparing Demo Data...
+      ///
+      /// Key: preparingDemoData
+      ///
+      /// Locales: en, uk
+      var preparingDemoData: RswiftResources.StringResource { .init(key: "preparingDemoData", tableName: "Global", source: source, developmentValue: "Preparing Demo Data...", comment: nil) }
 
       /// en translation: Price
       ///

--- a/TrackMyCafe.xcodeproj/project.pbxproj
+++ b/TrackMyCafe.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 71;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -568,6 +568,9 @@
 		F3BF4C7028265F400036B433 /* GoodsPriceModel.png in Resources */ = {isa = PBXBuildFile; fileRef = F3BF4C6B28265F400036B433 /* GoodsPriceModel.png */; };
 		F3BF4C7128265F400036B433 /* PurchaseModel.png in Resources */ = {isa = PBXBuildFile; fileRef = F3BF4C6C28265F400036B433 /* PurchaseModel.png */; };
 		F3C67912293929EF00E64D49 /* DefaultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C67911293929EF00E64D49 /* DefaultButton.swift */; };
+		F3D97EB82F4DF7D8006270AF /* DemoDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3D97EB72F4DF7D8006270AF /* DemoDataManager.swift */; };
+		F3D97EB92F4DF7D8006270AF /* DemoDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3D97EB72F4DF7D8006270AF /* DemoDataManager.swift */; };
+		F3D97EBA2F4DF7D8006270AF /* DemoDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3D97EB72F4DF7D8006270AF /* DemoDataManager.swift */; };
 		F3DA99BDDC0433656561976A /* OpexAggregationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287C00B3CD0E54955D1E9AAC /* OpexAggregationService.swift */; };
 		F3DB41B52EBDE2050095FBE1 /* NumericTextInputFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3DB41B42EBDE2050095FBE1 /* NumericTextInputFilter.swift */; };
 		F3DB41B62EBDE2050095FBE1 /* NumericTextInputFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3DB41B42EBDE2050095FBE1 /* NumericTextInputFilter.swift */; };
@@ -843,6 +846,7 @@
 		F3BF4C6B28265F400036B433 /* GoodsPriceModel.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = GoodsPriceModel.png; sourceTree = "<group>"; };
 		F3BF4C6C28265F400036B433 /* PurchaseModel.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = PurchaseModel.png; sourceTree = "<group>"; };
 		F3C67911293929EF00E64D49 /* DefaultButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultButton.swift; sourceTree = "<group>"; };
+		F3D97EB72F4DF7D8006270AF /* DemoDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoDataManager.swift; sourceTree = "<group>"; };
 		F3DB41B42EBDE2050095FBE1 /* NumericTextInputFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericTextInputFilter.swift; sourceTree = "<group>"; };
 		F3DB41B82EBDE2270095FBE1 /* UITextField+NumericInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+NumericInput.swift"; sourceTree = "<group>"; };
 		F3DD2196277AEF76001570D3 /* RealmProductsPriceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmProductsPriceModel.swift; sourceTree = "<group>"; };
@@ -874,61 +878,11 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		F324E60A2F486E99003A7469 /* Selection */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = Selection;
-			sourceTree = "<group>";
-		};
-		F3299A932F35065600EA6532 /* Cells */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = Cells;
-			sourceTree = "<group>";
-		};
-		F35E91AE2F49D7DA0050EB4A /* ProductCategories */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = ProductCategories;
-			sourceTree = "<group>";
-		};
-		F362781C2EE5508D00A69CFE /* Home */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = Home;
-			sourceTree = "<group>";
-		};
-		F3B7A8342EE220F0007BF216 /* Onboarding */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = Onboarding;
-			sourceTree = "<group>";
-		};
+		F324E60A2F486E99003A7469 /* Selection */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Selection; sourceTree = "<group>"; };
+		F3299A932F35065600EA6532 /* Cells */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Cells; sourceTree = "<group>"; };
+		F35E91AE2F49D7DA0050EB4A /* ProductCategories */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ProductCategories; sourceTree = "<group>"; };
+		F362781C2EE5508D00A69CFE /* Home */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Home; sourceTree = "<group>"; };
+		F3B7A8342EE220F0007BF216 /* Onboarding */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Onboarding; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2068,6 +2022,7 @@
 			isa = PBXGroup;
 			children = (
 				F32B52B62F2B6F3D0005E63D /* DomainIngredientDataService.swift */,
+				F3D97EB72F4DF7D8006270AF /* DemoDataManager.swift */,
 				F36217CC2EC04E5300965886 /* DomainProductPriceDataService.swift */,
 				F3E358022BF22B76005050CB /* DomainDB.swift */,
 				F36217C02EBF006C00965886 /* DomainCostDataService.swift */,
@@ -2472,9 +2427,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-TrackMyCafe Prod/Pods-TrackMyCafe Prod-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-TrackMyCafe Prod/Pods-TrackMyCafe Prod-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2489,9 +2448,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-TrackMyCafe Beta/Pods-TrackMyCafe Beta-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-TrackMyCafe Beta/Pods-TrackMyCafe Beta-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2639,9 +2602,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-TrackMyCafe Dev/Pods-TrackMyCafe Dev-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-TrackMyCafe Dev/Pods-TrackMyCafe Dev-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2741,6 +2708,7 @@
 				F3A640B02C3408A3006BCACD /* SubscriptionController.swift in Sources */,
 				F316A2F3273803CE0083E830 /* ProductListViewController.swift in Sources */,
 				F3410EB22BDD408B0007157B /* Settings.swift in Sources */,
+				F3D97EB82F4DF7D8006270AF /* DemoDataManager.swift in Sources */,
 				F3DB41BB2EBDE2270095FBE1 /* UITextField+NumericInput.swift in Sources */,
 				F37CB1742D5A8CE0006F1E89 /* AppLogger.swift in Sources */,
 				F39A5337273252A500C8F2D3 /* CostListViewController.swift in Sources */,
@@ -2929,6 +2897,7 @@
 				F3A640B12C3408A3006BCACD /* SubscriptionController.swift in Sources */,
 				F3B339E62C0B22FE0073F19A /* SettingsDataTableViewCell.swift in Sources */,
 				F3F6A60E2C2FEBDC000961C8 /* IAPReceiptAdapterLocalValidation.swift in Sources */,
+				F3D97EB92F4DF7D8006270AF /* DemoDataManager.swift in Sources */,
 				F3DB41B92EBDE2270095FBE1 /* UITextField+NumericInput.swift in Sources */,
 				F37CB1732D5A8CE0006F1E89 /* AppLogger.swift in Sources */,
 				F3B339E72C0B22FE0073F19A /* UIColor+Extension.swift in Sources */,
@@ -3117,6 +3086,7 @@
 				F3A640B22C3408A3006BCACD /* SubscriptionController.swift in Sources */,
 				F3B33A852C0B23450073F19A /* SettingsDataTableViewCell.swift in Sources */,
 				F3F6A60F2C2FEBDC000961C8 /* IAPReceiptAdapterLocalValidation.swift in Sources */,
+				F3D97EBA2F4DF7D8006270AF /* DemoDataManager.swift in Sources */,
 				F3DB41BA2EBDE2270095FBE1 /* UITextField+NumericInput.swift in Sources */,
 				F37CB1722D5A8CE0006F1E89 /* AppLogger.swift in Sources */,
 				F3B33A862C0B23450073F19A /* UIColor+Extension.swift in Sources */,

--- a/TrackMyCafe/Resources/Localization/en.lproj/Global.strings
+++ b/TrackMyCafe/Resources/Localization/en.lproj/Global.strings
@@ -385,3 +385,12 @@
 "onboardingSettingsTypesMessage" = "Configure different order types here.";
 "logout" = "Logout";
 "account" = "Account";
+
+// MARK: - Demo Data
+"preparingDemoData" = "Preparing Demo Data...";
+"deleteDemoData" = "Delete Demo Data";
+"deleteDemoDataTitle" = "Delete Demo Data?";
+"deleteDemoDataMessage" = "This will remove all demo data but keep your personal entries.";
+"deleting" = "Deleting...";
+"demoDataTitle" = "Demo Data";
+"demoDataMessage" = "Would you like to fill the app with demo data to see how it works?";

--- a/TrackMyCafe/Resources/Localization/uk.lproj/Global.strings
+++ b/TrackMyCafe/Resources/Localization/uk.lproj/Global.strings
@@ -385,3 +385,12 @@
 
 // MARK: - Reports
 "reportsTitle" = "Звіти";
+
+// MARK: - Demo Data
+"preparingDemoData" = "Підготовка демо-даних...";
+"deleteDemoData" = "Видалити демо-дані";
+"deleteDemoDataTitle" = "Видалити демо-дані?";
+"deleteDemoDataMessage" = "Це видалить усі демо-записи, але збереже ваші особисті дані.";
+"deleting" = "Видалення...";
+"demoDataTitle" = "Демо-дані";
+"demoDataMessage" = "Бажаєте заповнити додаток демо-даними для ознайомлення?";

--- a/TrackMyCafe/Services/Domain/DemoDataManager.swift
+++ b/TrackMyCafe/Services/Domain/DemoDataManager.swift
@@ -1,0 +1,163 @@
+//
+//  DemoDataManager.swift
+//  TrackMyCafe
+//
+//  Created by AI Assistant on 24.02.2026.
+//
+
+import Foundation
+
+struct DemoDataManifest: Codable {
+    var typeIds: [String] = []
+    var productIds: [String] = []
+    var ingredientIds: [String] = []
+    var purchaseIds: [String] = []
+    var inventoryAdjustmentIds: [String] = []
+    var orderIds: [String] = []
+    var orderItemIds: [String] = []
+    var expenseIds: [String] = []
+}
+
+final class DemoDataManager {
+    static let shared = DemoDataManager()
+    private let kManifestKey = "demo_data_manifest"
+
+    var isDemoDataPresent: Bool {
+        return UserDefaults.standard.data(forKey: kManifestKey) != nil
+    }
+
+    func saveManifest(_ manifest: DemoDataManifest) {
+        if let data = try? JSONEncoder().encode(manifest) {
+            UserDefaults.standard.set(data, forKey: kManifestKey)
+        }
+    }
+
+    func getManifest() -> DemoDataManifest? {
+        guard let data = UserDefaults.standard.data(forKey: kManifestKey) else { return nil }
+        return try? JSONDecoder().decode(DemoDataManifest.self, from: data)
+    }
+
+    func clearManifest() {
+        UserDefaults.standard.removeObject(forKey: kManifestKey)
+    }
+
+    // MARK: - Incremental Saving
+    func addTypeId(_ id: String) {
+        var manifest = getManifest() ?? DemoDataManifest()
+        manifest.typeIds.append(id)
+        saveManifest(manifest)
+    }
+
+    func addProductId(_ id: String) {
+        var manifest = getManifest() ?? DemoDataManifest()
+        manifest.productIds.append(id)
+        saveManifest(manifest)
+    }
+
+    func addIngredientId(_ id: String) {
+        var manifest = getManifest() ?? DemoDataManifest()
+        manifest.ingredientIds.append(id)
+        saveManifest(manifest)
+    }
+
+    func addPurchaseId(_ id: String) {
+        var manifest = getManifest() ?? DemoDataManifest()
+        manifest.purchaseIds.append(id)
+        saveManifest(manifest)
+    }
+
+    func addInventoryAdjustmentId(_ id: String) {
+        var manifest = getManifest() ?? DemoDataManifest()
+        manifest.inventoryAdjustmentIds.append(id)
+        saveManifest(manifest)
+    }
+
+    func addOrderId(_ id: String) {
+        var manifest = getManifest() ?? DemoDataManifest()
+        manifest.orderIds.append(id)
+        saveManifest(manifest)
+    }
+
+    func addOrderItemId(_ id: String) {
+        var manifest = getManifest() ?? DemoDataManifest()
+        manifest.orderItemIds.append(id)
+        saveManifest(manifest)
+    }
+
+    func addExpenseId(_ id: String) {
+        var manifest = getManifest() ?? DemoDataManifest()
+        manifest.expenseIds.append(id)
+        saveManifest(manifest)
+    }
+
+    func deleteDemoData(completion: @escaping (Bool) -> Void) {
+        guard let manifest = getManifest() else {
+            completion(true)
+            return
+        }
+
+        Task {
+            print("Deleting demo data...")
+            // Delete Order Items
+            for id in manifest.orderItemIds {
+                await delete(collection: FirebaseCollections.productOfOrders, id: id)
+            }
+            print("Deleted \(manifest.orderItemIds.count) order items")
+
+            // Delete Orders
+            for id in manifest.orderIds {
+                await delete(collection: FirebaseCollections.orders, id: id)
+            }
+            print("Deleted \(manifest.orderIds.count) orders")
+
+            // Delete Expenses
+            for id in manifest.expenseIds {
+                await delete(collection: FirebaseCollections.opexExpenses, id: id)
+            }
+            print("Deleted \(manifest.expenseIds.count) expenses")
+
+            // Delete Purchases
+            for id in manifest.purchaseIds {
+                await delete(collection: FirebaseCollections.purchases, id: id)
+            }
+            print("Deleted \(manifest.purchaseIds.count) purchases")
+
+            // Delete Inventory Adjustments
+            for id in manifest.inventoryAdjustmentIds {
+                await delete(collection: FirebaseCollections.inventoryAdjustments, id: id)
+            }
+            print("Deleted \(manifest.inventoryAdjustmentIds.count) adjustments")
+
+            // Delete Products
+            for id in manifest.productIds {
+                await delete(collection: FirebaseCollections.productsPrice, id: id)
+            }
+            print("Deleted \(manifest.productIds.count) products")
+
+            // Delete Ingredients
+            for id in manifest.ingredientIds {
+                await delete(collection: FirebaseCollections.ingredients, id: id)
+            }
+            print("Deleted \(manifest.ingredientIds.count) ingredients")
+
+            // Delete Types
+            for id in manifest.typeIds {
+                await delete(collection: FirebaseCollections.types, id: id)
+            }
+            print("Deleted \(manifest.typeIds.count) types")
+
+            clearManifest()
+            await MainActor.run {
+                completion(true)
+            }
+        }
+    }
+
+    private func delete(collection: String, id: String) async {
+        await withCheckedContinuation { continuation in
+            DomainDatabaseService.shared.delete(collection: collection, documentId: id) { _ in
+                continuation.resume()
+            }
+        }
+    }
+}

--- a/TrackMyCafe/Services/Domain/DomainDatabaseService.swift
+++ b/TrackMyCafe/Services/Domain/DomainDatabaseService.swift
@@ -756,6 +756,22 @@ class DomainDatabaseService: DomainDB {
         }
     }
 
+    // MARK: - Generic Delete Operation
+    func delete(collection: String, documentId: String, completion: @escaping (Bool) -> Void) {
+        FirestoreDatabaseService.shared.delete(collection: collection, documentId: documentId) {
+            result in
+            switch result {
+            case .success:
+                self.logger.info("Document \(documentId) deleted from \(collection) successfully")
+                completion(true)
+            case .failure(let error):
+                self.logger.error(
+                    "Failed to delete document \(documentId) from \(collection): \(error)")
+                completion(false)
+            }
+        }
+    }
+
     // MARK: - general Operations
 
     var orderIdMap: [String: String] = [:]
@@ -767,15 +783,29 @@ class DomainDatabaseService: DomainDB {
     @MainActor
     func seedTestData(forDays days: Int) async {
         await cleanDatabase()
+        var manifest: DemoDataManifest? = nil
+        await seedDemoData(days: days, manifest: &manifest)
+    }
 
+    @MainActor
+    func seedUserDemoData() async {
+        // Clear old manifest if exists before starting new seeding
+        DemoDataManager.shared.clearManifest()
+
+        var manifest: DemoDataManifest? = nil  // We don't use this local manifest anymore for persistence, but keep signature
+        await seedDemoData(days: 14, manifest: &manifest)
+    }
+
+    @MainActor
+    private func seedDemoData(days: Int, manifest: inout DemoDataManifest?) async {
         // Wait a bit to ensure Firestore processes deletions
         try? await Task.sleep(nanoseconds: 1_000_000_000)  // 1 second
 
         let isUkrainian = Locale.current.languageCode == "uk"
 
-        let types = await seedTypes()
-        var products = await seedProducts(isUkrainian: isUkrainian)
-        var ingredients = await seedIngredients(isUkrainian: isUkrainian)
+        let types = await seedTypes(manifest: &manifest)
+        var products = await seedProducts(isUkrainian: isUkrainian, manifest: &manifest)
+        var ingredients = await seedIngredients(isUkrainian: isUkrainian, manifest: &manifest)
 
         await assignRecipes(to: &products, ingredients: ingredients, isUkrainian: isUkrainian)
 
@@ -784,7 +814,8 @@ class DomainDatabaseService: DomainDB {
             products: products,
             ingredients: &ingredients,
             types: types,
-            isUkrainian: isUkrainian
+            isUkrainian: isUkrainian,
+            manifest: &manifest
         )
     }
 }
@@ -800,7 +831,7 @@ extension DomainDatabaseService {
         }
     }
 
-    fileprivate func seedTypes() async -> [TypeModel] {
+    fileprivate func seedTypes(manifest: inout DemoDataManifest?) async -> [TypeModel] {
         let typeHall = R.string.global.typeHall()
         let typeTakeaway = R.string.global.typeTakeaway()
         let typeDelivery = R.string.global.typeDelivery()
@@ -811,6 +842,7 @@ extension DomainDatabaseService {
         ]
 
         for t in types {
+            DemoDataManager.shared.addTypeId(t.id)
             await withCheckedContinuation { continuation in
                 self.saveType(model: t) { success in
                     if !success { self.logger.error("Failed to seed type: \(t.name)") }
@@ -821,7 +853,9 @@ extension DomainDatabaseService {
         return types
     }
 
-    fileprivate func seedProducts(isUkrainian: Bool) async -> [ProductsPriceModel] {
+    fileprivate func seedProducts(isUkrainian: Bool, manifest: inout DemoDataManifest?) async
+        -> [ProductsPriceModel]
+    {
         let catalog: [(uk: String, en: String, price: Double)] = [
             ("Еспресо", "Espresso", 8),
             ("Еспресо з молоком", "Espresso with milk", 10),
@@ -846,6 +880,7 @@ extension DomainDatabaseService {
         }
 
         for p in products {
+            DemoDataManager.shared.addProductId(p.id)
             await withCheckedContinuation { continuation in
                 self.saveProductsPrice(productPrice: p) { success in
                     if !success { self.logger.error("Failed to seed product: \(p.name)") }
@@ -856,7 +891,9 @@ extension DomainDatabaseService {
         return products
     }
 
-    fileprivate func seedIngredients(isUkrainian: Bool) async -> [IngredientModel] {
+    fileprivate func seedIngredients(isUkrainian: Bool, manifest: inout DemoDataManifest?) async
+        -> [IngredientModel]
+    {
         let ingredientCatalog: [(uk: String, en: String, unit: MeasurementUnit, baseCost: Double)] =
             [
                 ("Молоко", "Milk", .l, 35.0),
@@ -879,6 +916,7 @@ extension DomainDatabaseService {
                 unit: item.unit
             )
             createdIngredients.append(ingredient)
+            DemoDataManager.shared.addIngredientId(ingredient.id)
 
             await withCheckedContinuation { continuation in
                 self.saveIngredient(model: ingredient) { success in
@@ -979,21 +1017,26 @@ extension DomainDatabaseService {
         products: [ProductsPriceModel],
         ingredients: inout [IngredientModel],
         types: [TypeModel],
-        isUkrainian: Bool
+        isUkrainian: Bool,
+        manifest: inout DemoDataManifest?
     ) async {
         let calendar = Calendar.current
         for i in 0..<max(1, days) {
             guard let date = calendar.date(byAdding: .day, value: -i, to: Date()) else { continue }
 
-            await processPurchases(date: date, ingredients: &ingredients)
+            await processPurchases(date: date, ingredients: &ingredients, manifest: &manifest)
             await processInventoryAdjustments(
-                date: date, ingredients: &ingredients, isUkrainian: isUkrainian)
+                date: date, ingredients: &ingredients, isUkrainian: isUkrainian, manifest: &manifest
+            )
             await processOrders(
-                date: date, dayIndex: i, products: products, types: types, isUkrainian: isUkrainian)
+                date: date, dayIndex: i, products: products, types: types, isUkrainian: isUkrainian,
+                manifest: &manifest)
         }
     }
 
-    fileprivate func processPurchases(date: Date, ingredients: inout [IngredientModel]) async {
+    fileprivate func processPurchases(
+        date: Date, ingredients: inout [IngredientModel], manifest: inout DemoDataManifest?
+    ) async {
         if !ingredients.isEmpty && Int.random(in: 0...100) < 30 {
             let purchaseCount = Int.random(in: 1...3)
             for _ in 0..<purchaseCount {
@@ -1006,6 +1049,7 @@ extension DomainDatabaseService {
                         id: UUID().uuidString, date: date, ingredientId: randomIngredient.id,
                         quantity: qty, price: price, supplierId: nil
                     )
+                    DemoDataManager.shared.addPurchaseId(purchase.id)
 
                     // Update stock and avg cost
                     let oldTotalValue =
@@ -1045,7 +1089,8 @@ extension DomainDatabaseService {
     }
 
     fileprivate func processInventoryAdjustments(
-        date: Date, ingredients: inout [IngredientModel], isUkrainian: Bool
+        date: Date, ingredients: inout [IngredientModel], isUkrainian: Bool,
+        manifest: inout DemoDataManifest?
     ) async {
         if !ingredients.isEmpty && Int.random(in: 0...100) < 10 {
             if let randomIngredient = ingredients.randomElement() {
@@ -1053,6 +1098,7 @@ extension DomainDatabaseService {
                     id: UUID().uuidString, date: date, ingredientId: randomIngredient.id,
                     quantityDelta: -1.0, reason: isUkrainian ? "Списання (псування)" : "Spoilage"
                 )
+                DemoDataManager.shared.addInventoryAdjustmentId(adjustment.id)
 
                 await withCheckedContinuation { continuation in
                     self.saveInventoryAdjustment(model: adjustment) { success in
@@ -1081,7 +1127,7 @@ extension DomainDatabaseService {
 
     fileprivate func processOrders(
         date: Date, dayIndex: Int, products: [ProductsPriceModel], types: [TypeModel],
-        isUkrainian: Bool
+        isUkrainian: Bool, manifest: inout DemoDataManifest?
     ) async {
         let typeCount = (dayIndex % 3) + 1
         var rotated = types
@@ -1115,6 +1161,7 @@ extension DomainDatabaseService {
                 id: orderId, date: date, type: type.name, sum: total,
                 cash: cash, card: card
             )
+            DemoDataManager.shared.addOrderId(orderId)
 
             let savedOrderId: String? = await withCheckedContinuation { continuation in
                 self.saveOrder(order: order) { id in
@@ -1126,6 +1173,7 @@ extension DomainDatabaseService {
             let targetOrderId = savedOrderId ?? orderId
             for var item in orderItems {
                 item.orderId = targetOrderId
+                DemoDataManager.shared.addOrderItemId(item.id)
                 await withCheckedContinuation { continuation in
                     self.saveProduct(order: item) { success in
                         if !success { self.logger.error("Failed to seed order item") }
@@ -1141,12 +1189,13 @@ extension DomainDatabaseService {
             await processExpenses(
                 date: date, dayIndex: dayIndex,
                 loopIndex: dayTypes.firstIndex(where: { $0.id == type.id }) ?? 0,
-                count: dayTypes.count, isUkrainian: isUkrainian)
+                count: dayTypes.count, isUkrainian: isUkrainian, manifest: &manifest)
         }
     }
 
     fileprivate func processExpenses(
-        date: Date, dayIndex: Int, loopIndex: Int, count: Int, isUkrainian: Bool
+        date: Date, dayIndex: Int, loopIndex: Int, count: Int, isUkrainian: Bool,
+        manifest: inout DemoDataManifest?
     ) async {
         let costCatalog: [(uk: String, en: String, base: Double)] = [
             ("Оренда", "Rent", 1200),
@@ -1173,6 +1222,7 @@ extension DomainDatabaseService {
                 id: UUID().uuidString, date: date, categoryId: isUkrainian ? "Загальні" : "General",
                 amount: amount, note: name
             )
+            DemoDataManager.shared.addExpenseId(opex.id)
 
             await withCheckedContinuation { continuation in
                 self.saveOpexExpense(model: opex) { success in

--- a/TrackMyCafe/View Layer/Flow/Home/View/HomeHeaderView.swift
+++ b/TrackMyCafe/View Layer/Flow/Home/View/HomeHeaderView.swift
@@ -5,6 +5,18 @@ final class HomeHeaderView: UIView {
     var onAddIncome: (() -> Void)?
     var onAddExpense: (() -> Void)?
     var onPeriodChanged: ((Int) -> Void)?
+    var onDeleteDemoData: (() -> Void)?
+
+    private let deleteDemoDataButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle(R.string.global.deleteDemoData(), for: .normal)
+        button.backgroundColor = .systemRed
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 12
+        button.titleLabel?.font = .systemFont(ofSize: 17, weight: .semibold)
+        button.isHidden = true
+        return button
+    }()
 
     private let titleLabel: UILabel = {
         let l = UILabel()
@@ -61,8 +73,12 @@ final class HomeHeaderView: UIView {
         expenses: Double,
         profit: Double,
         cash: Double,
-        card: Double
+        card: Double,
+        showDeleteDemoData: Bool = false
     ) {
+        deleteDemoDataButton.isHidden = !showDeleteDemoData
+        deleteDemoDataButton.addTarget(self, action: #selector(deleteDemoDataTap), for: .touchUpInside)
+
         dateLabel.text = DateFormatter.appFullDate.string(from: date)
         periodControl.selectedSegmentIndex = period.rawValue
 
@@ -135,9 +151,11 @@ final class HomeHeaderView: UIView {
         kpiRow1.addArrangedSubview(expensesCard)
         kpiRow1.addArrangedSubview(profitCard)
 
+        deleteDemoDataButton.height(UIConstants.buttonHeight)
+        
         let contentStack = UIStackView(
             arrangedSubviews: [
-                headerStack, actionsStack, periodControl, kpiRow1, kpiRow2, balanceCard,
+                deleteDemoDataButton, headerStack, actionsStack, periodControl, kpiRow1, kpiRow2, balanceCard,
             ]
         )
         contentStack.axis = NSLayoutConstraint.Axis.vertical
@@ -163,6 +181,7 @@ final class HomeHeaderView: UIView {
     @objc private func incomeTap() { onAddIncome?() }
     @objc private func expenseTap() { onAddExpense?() }
     @objc private func periodChanged() { onPeriodChanged?(periodControl.selectedSegmentIndex) }
+    @objc private func deleteDemoDataTap() { onDeleteDemoData?() }
 }
 
 // MARK: - Small UI Components

--- a/TrackMyCafe/View Layer/Flow/Home/View/HomeViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Home/View/HomeViewController.swift
@@ -1,4 +1,5 @@
 import TinyConstraints
+import SVProgressHUD
 import UIKit
 
 final class HomeViewController: UIViewController {
@@ -33,6 +34,9 @@ final class HomeViewController: UIViewController {
     headerView.onPeriodChanged = { [weak self] idx in
         self?.applyPeriodChange(index: idx)
     }
+    headerView.onDeleteDemoData = { [weak self] in
+        self?.confirmDeleteDemoData()
+    }
 
     view.addSubview(tableView)
     tableView.edgesToSuperview(
@@ -45,11 +49,23 @@ final class HomeViewController: UIViewController {
     )
 
     Task { await loadData() }
+    
+    NotificationCenter.default.addObserver(self, selector: #selector(dataDidUpdate), name: NSNotification.Name("DataDidUpdate"), object: nil)
+  }
+  
+  @objc private func dataDidUpdate() {
+      Task { await loadData() }
   }
   
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
+    navigationController?.setNavigationBarHidden(true, animated: animated)
     Task { await loadData() }
+  }
+
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    navigationController?.setNavigationBarHidden(false, animated: animated)
   }
 
   override func viewDidLayoutSubviews() {
@@ -104,7 +120,32 @@ final class HomeViewController: UIViewController {
     Task { await loadData() }
   }
   
-  private func applyPeriodChange(index: Int) {
+  private func confirmDeleteDemoData() {
+        let alert = UIAlertController(
+            title: R.string.global.deleteDemoDataTitle(),
+            message: R.string.global.deleteDemoDataMessage(),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: R.string.global.cancel(), style: .cancel))
+        alert.addAction(
+            UIAlertAction(title: R.string.global.delete(), style: .destructive) { _ in
+                SVProgressHUD.show(withStatus: R.string.global.deleting())
+                DemoDataManager.shared.deleteDemoData { success in
+                    DispatchQueue.main.async {
+                        SVProgressHUD.dismiss()
+                        if success {
+                            SVProgressHUD.showSuccess(withStatus: R.string.global.actionDone())
+                            self.reloadAfterAction()
+                        } else {
+                            SVProgressHUD.showError(withStatus: R.string.global.error())
+                        }
+                    }
+                }
+            })
+        present(alert, animated: true)
+    }
+
+    private func applyPeriodChange(index: Int) {
     let period: DashboardPeriod
     switch index {
     case 0: period = .day
@@ -135,7 +176,8 @@ final class HomeViewController: UIViewController {
       expenses: viewModel.monthExpenses,
       profit: viewModel.monthProfit,
       cash: viewModel.cashBalance,
-      card: viewModel.cardBalance
+      card: viewModel.cardBalance,
+      showDeleteDemoData: DemoDataManager.shared.isDemoDataPresent
     )
   }
 }

--- a/TrackMyCafe/View Layer/Flow/MainTabBarController.swift
+++ b/TrackMyCafe/View Layer/Flow/MainTabBarController.swift
@@ -5,6 +5,8 @@
 //  Created by Леонід Квіт on 02.11.2021.
 //
 
+import FirebaseAuth
+import SVProgressHUD
 import UIKit
 
 class MainTabBarController: UITabBarController {
@@ -15,6 +17,51 @@ class MainTabBarController: UITabBarController {
         setupTabBar()
         applyTabBarAppearance()
         navigationController?.view.backgroundColor = UIColor.NavBar.background
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        checkAndSeedDemoDataIfNeeded()
+    }
+
+    private func checkAndSeedDemoDataIfNeeded() {
+        guard let userId = Auth.auth().currentUser?.uid else { return }
+        let hasCheckedDemoDataKey = "hasCheckedDemoData_\(userId)"
+
+        let hasCheckedDemoData = UserDefaults.standard.bool(forKey: hasCheckedDemoDataKey)
+        guard !hasCheckedDemoData else { return }
+
+        // Mark as checked so we don't check again on subsequent launches
+        UserDefaults.standard.set(true, forKey: hasCheckedDemoDataKey)
+
+        // Check if DB is empty (simple check: if no products, likely empty)
+        DomainDatabaseService.shared.fetchProductsPrice { [weak self] products in
+            guard products.isEmpty else { return }
+
+            DispatchQueue.main.async {
+                self?.seedDemoData()
+            }
+        }
+    }
+
+    private func seedDemoData() {
+        SVProgressHUD.show(
+            withStatus: R.string.global.preparingDemoData())
+        Task {
+            await DomainDatabaseService.shared.seedUserDemoData()
+            await MainActor.run {
+                SVProgressHUD.dismiss()
+                SVProgressHUD.showSuccess(withStatus: R.string.global.success())
+                // Notify other controllers to reload data
+                NotificationCenter.default.post(
+                    name: NSNotification.Name("DataDidUpdate"), object: nil)
+
+                // If the current selected view controller responds to reloading, we might want to trigger it manually
+                // But NotificationCenter should handle it if observers are set up.
+                // Since this happens on first launch, viewControllers might already be loaded.
+                // We can iterate and reload if they have a reload method, but notification is cleaner.
+            }
+        }
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -109,19 +156,19 @@ class MainTabBarController: UITabBarController {
             viewController: HomeViewController(),
             itemName: R.string.global.home(),
             itemImage: SystemImages.home)
-        
+
         // Tab 2: Income (Orders)
         let ordersViewController = createNavController(
             viewController: OrderListViewController(),
-            itemName: R.string.global.income(), // Or "Orders" / "POS"
+            itemName: R.string.global.income(),  // Or "Orders" / "POS"
             itemImage: SystemImages.mug)
-        
+
         // Tab 3: Costs & Inventory (New Container)
         let costsTabViewController = createNavController(
             viewController: CostsTabViewController(),
-            itemName: R.string.global.costs(), // Should ideally be "Costs & Inventory"
+            itemName: R.string.global.costs(),  // Should ideally be "Costs & Inventory"
             itemImage: SystemImages.bag)
-        
+
         // Tab 4: Reports (Placeholder for now, using existing logic or empty)
         // For now, let's skip Reports tab creation until implemented, or use a placeholder
         // Using PurchaseListViewController as a temporary placeholder if needed,
@@ -129,18 +176,18 @@ class MainTabBarController: UITabBarController {
         // For MVP 2.0 structure, let's keep 5 tabs if possible, or 4.
         // Let's create a temporary Reports placeholder.
         let reportsViewController = createNavController(
-            viewController: UIViewController(), // Placeholder
+            viewController: UIViewController(),  // Placeholder
             itemName: R.string.global.reportsTitle(),
-            itemImage: "chart.bar") // SystemImages.chartBar if exists, or string
+            itemImage: "chart.bar")  // SystemImages.chartBar if exists, or string
         reportsViewController.viewControllers.first?.view.backgroundColor = .systemBackground
         reportsViewController.viewControllers.first?.title = R.string.global.reportsTitle()
-        
+
         // Tab 5: Settings
         let settingsViewController = createNavController(
             viewController: SettingListViewController(),
             itemName: R.string.global.menuSettings(),
             itemImage: SystemImages.gearshape)
-        
+
         // Update: Removed separate Purchases tab (now in Tab 3)
         // Added Reports placeholder
         viewControllers = [

--- a/TrackMyCafe/View Layer/Flow/Settings/SettingList/View/SettingListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/SettingList/View/SettingListViewController.swift
@@ -75,6 +75,7 @@ class SettingListViewController: UIViewController, UITableViewDelegate, UITableV
 
         view.backgroundColor = UIColor.Main.background
         title = R.string.global.menuSettings()
+        navigationController?.navigationBar.prefersLargeTitles = false
 
         tableView.delegate = self
         tableView.dataSource = self
@@ -233,7 +234,7 @@ class SettingListViewController: UIViewController, UITableViewDelegate, UITableV
         )
 
         // 5. App Info
-        let appInfoOptions: [SettingsOptionType] = [
+        var appInfoOptions: [SettingsOptionType] = [
             .staticCell(
                 model: SettingsStaticOption(
                     title: R.string.global.restartOnboarding(),
@@ -262,6 +263,21 @@ class SettingListViewController: UIViewController, UITableViewDelegate, UITableV
                     self.presentFeedbackEmail()
                 }),
         ]
+
+        if DemoDataManager.shared.isDemoDataPresent {
+            appInfoOptions.append(
+                .staticCell(
+                    model: SettingsStaticOption(
+                        title: R.string.global.deleteDemoData(),
+                        icon: UIImage(systemName: "trash"),
+                        iconBackgroundColor: .systemRed
+                    ) {
+                        self.confirmDeleteDemoData()
+                    }
+                )
+            )
+        }
+
         models.append(
             Section(
                 title: R.string.global.settingsSectionAppInfo(), footer: nil, option: appInfoOptions
@@ -554,6 +570,33 @@ class SettingListViewController: UIViewController, UITableViewDelegate, UITableV
                 title: R.string.global.okButton(),
                 style: .default
             ))
+        present(alert, animated: true)
+    }
+
+    private func confirmDeleteDemoData() {
+        let alert = UIAlertController(
+            title: R.string.global.deleteDemoDataTitle(),
+            message: R.string.global.deleteDemoDataMessage(),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: R.string.global.cancel(), style: .cancel))
+        alert.addAction(
+            UIAlertAction(title: R.string.global.delete(), style: .destructive) { _ in
+                SVProgressHUD.show(
+                    withStatus: R.string.global.deleting())
+                DemoDataManager.shared.deleteDemoData { success in
+                    DispatchQueue.main.async {
+                        SVProgressHUD.dismiss()
+                        if success {
+                            self.configure()
+                            self.tableView.reloadData()
+                            SVProgressHUD.showSuccess(withStatus: R.string.global.actionDone())
+                        } else {
+                            SVProgressHUD.showError(withStatus: R.string.global.error())
+                        }
+                    }
+                }
+            })
         present(alert, animated: true)
     }
 }


### PR DESCRIPTION
Resolves #162

Changes:
- Added `DemoDataManager` to persist created demo object IDs incrementally.
- Added "Delete Demo Data" button to `HomeHeaderView`, visible only when demo data exists.
- Updated `MainTabBarController` to check for demo data seeding per user (using `userId` in `UserDefaults` key).
- Fixed double navigation bar issue in `HomeViewController` by hiding the system navigation bar on appearance.
- Fixed large title visual glitch in `SettingListViewController` by disabling large titles for that screen.
- Removed `if manifest != nil` checks in `DomainDatabaseService` to ensure demo data is always tracked.