### PR TITLE
feat(settings): add localized privacy policy and terms of service links

### DIFF
--- a/R.generated.swift
+++ b/R.generated.swift
@@ -218,7 +218,7 @@ struct _R {
       var useBioAuth: RswiftResources.StringResource1<String> { .init(key: "useBioAuth", tableName: "Auth", source: source, developmentValue: "Use %@ for quick authorization", comment: nil) }
     }
 
-    /// This `_R.string.global` struct is generated, and contains static references to 325 localization keys.
+    /// This `_R.string.global` struct is generated, and contains static references to 326 localization keys.
     struct global {
       let source: RswiftResources.StringResource.Source
 
@@ -2286,6 +2286,13 @@ struct _R {
       ///
       /// Locales: en, uk
       var technicianNoteGoesHere: RswiftResources.StringResource { .init(key: "technicianNoteGoesHere", tableName: "Global", source: source, developmentValue: "Technician note goes here", comment: nil) }
+
+      /// en translation: Terms of Service
+      ///
+      /// Key: termsOfService
+      ///
+      /// Locales: en, uk
+      var termsOfService: RswiftResources.StringResource { .init(key: "termsOfService", tableName: "Global", source: source, developmentValue: "Terms of Service", comment: nil) }
 
       /// en translation: Terms of Use
       ///

--- a/TrackMyCafe/Resources/Localization/en.lproj/Global.strings
+++ b/TrackMyCafe/Resources/Localization/en.lproj/Global.strings
@@ -394,3 +394,7 @@
 "deleting" = "Deleting...";
 "demoDataTitle" = "Demo Data";
 "demoDataMessage" = "Would you like to fill the app with demo data to see how it works?";
+
+// MARK: - Legal
+"privacyPolicy" = "Privacy Policy";
+"termsOfService" = "Terms of Service";

--- a/TrackMyCafe/Resources/Localization/uk.lproj/Global.strings
+++ b/TrackMyCafe/Resources/Localization/uk.lproj/Global.strings
@@ -394,3 +394,7 @@
 "deleting" = "Видалення...";
 "demoDataTitle" = "Демо-дані";
 "demoDataMessage" = "Бажаєте заповнити додаток демо-даними для ознайомлення?";
+
+// MARK: - Legal
+"privacyPolicy" = "Політика конфіденційності";
+"termsOfService" = "Умови використання";

--- a/TrackMyCafe/View Layer/Flow/Settings/SettingList/View/SettingListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/SettingList/View/SettingListViewController.swift
@@ -10,6 +10,7 @@ import MessageUI
 import RealmSwift
 import SVProgressHUD
 import UIKit
+import SafariServices
 
 struct Section {
     let title: String
@@ -253,6 +254,24 @@ class SettingListViewController: UIViewController, UITableViewDelegate, UITableV
                             OnboardingManager.shared.startIfNeeded(for: .settingsTypes, on: self)
                         })
                     self.present(alert, animated: true)
+                }),
+            .staticCell(
+                model: SettingsStaticOption(
+                    title: NSLocalizedString("privacyPolicy", tableName: "Global", comment: ""),
+                    icon: UIImage(systemName: "hand.raised.fill"),
+                    iconBackgroundColor: .systemGray
+                ) { [weak self] in
+                    guard let self = self else { return }
+                    self.openSafari(url: self.getLegalUrl(type: .privacy))
+                }),
+            .staticCell(
+                model: SettingsStaticOption(
+                    title: NSLocalizedString("termsOfService", tableName: "Global", comment: ""),
+                    icon: UIImage(systemName: "doc.text.fill"),
+                    iconBackgroundColor: .systemGray
+                ) { [weak self] in
+                    guard let self = self else { return }
+                    self.openSafari(url: self.getLegalUrl(type: .terms))
                 }),
             .staticCell(
                 model: SettingsStaticOption(
@@ -598,6 +617,36 @@ class SettingListViewController: UIViewController, UITableViewDelegate, UITableV
                 }
             })
         present(alert, animated: true)
+    }
+
+    // MARK: - Safari
+    private func openSafari(url: String) {
+        guard let url = URL(string: url) else { return }
+        let safariVC = SFSafariViewController(url: url)
+        safariVC.modalPresentationStyle = .pageSheet
+        present(safariVC, animated: true)
+    }
+
+    // MARK: - Legal URLs
+    private enum LegalDocType {
+        case privacy
+        case terms
+    }
+
+    private func getLegalUrl(type: LegalDocType) -> String {
+        // Check if the current language is Ukrainian
+        let isUkrainian = Locale.current.languageCode == "uk"
+
+        switch type {
+        case .privacy:
+            return isUkrainian
+                ? "https://leokvit.notion.site/313f9211d4378065b441d8876d169bec?source=copy_link" // TODO: Replace with actual UA link
+                : "https://leokvit.notion.site/Privacy-Policy-313f9211d437808aaf71cd2390e4671d?source=copy_link"
+        case .terms:
+            return isUkrainian
+                ? "https://leokvit.notion.site/Terms-of-Service-313f9211d43780458359c1e9e7bf0076?source=copy_link" // TODO: Replace with actual UA link
+                : "https://leokvit.notion.site/Terms-of-Service-313f9211d4378018b630fe6d2bfbbe09?source=copy_link"
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds Privacy Policy and Terms of Service links to the Settings screen, as required for App Store submission.

### Changes:
- Added localized strings for "Privacy Policy" and "Terms of Service" in English and Ukrainian.
- Updated `SettingListViewController` to include these options.
- Implemented `SFSafariViewController` to open the links within the app.
- Added logic to switch between English and Ukrainian versions of the legal documents based on the device language.

### References:
Closes #165