### PR TITLE
feat(tabbar): temporarily hide reports tab

### DIFF
--- a/TrackMyCafe/View Layer/Flow/MainTabBarController.swift
+++ b/TrackMyCafe/View Layer/Flow/MainTabBarController.swift
@@ -175,12 +175,12 @@ class MainTabBarController: UITabBarController {
         // but since Purchases are now in Tab 3, we can leave Tab 4 for Reports later.
         // For MVP 2.0 structure, let's keep 5 tabs if possible, or 4.
         // Let's create a temporary Reports placeholder.
-        let reportsViewController = createNavController(
-            viewController: UIViewController(),  // Placeholder
-            itemName: R.string.global.reportsTitle(),
-            itemImage: "chart.bar")  // SystemImages.chartBar if exists, or string
-        reportsViewController.viewControllers.first?.view.backgroundColor = .systemBackground
-        reportsViewController.viewControllers.first?.title = R.string.global.reportsTitle()
+//        let reportsViewController = createNavController(
+//            viewController: UIViewController(),  // Placeholder
+//            itemName: R.string.global.reportsTitle(),
+//            itemImage: "chart.bar")  // SystemImages.chartBar if exists, or string
+//        reportsViewController.viewControllers.first?.view.backgroundColor = .systemBackground
+//        reportsViewController.viewControllers.first?.title = R.string.global.reportsTitle()
 
         // Tab 5: Settings
         let settingsViewController = createNavController(
@@ -194,7 +194,7 @@ class MainTabBarController: UITabBarController {
             homeViewController,
             ordersViewController,
             costsTabViewController,
-            reportsViewController,
+            // reportsViewController,
             settingsViewController,
         ]
     }


### PR DESCRIPTION
Closes #167

## Plan
Temporarily comment out the Reports tab initialization and usage in MainTabBarController as it is not ready/needed yet.

## Code
Commented out `reportsViewController` and removed it from `viewControllers`.

## Expected Outcome
The Reports tab will no longer be visible in the main tab bar. The app should compile and run without errors.

## Validation
Verified locally by checking the tab bar items.