### PR TITLE
feat(account): implement delete account functionality

### DIFF
--- a/TrackMyCafe.xcodeproj/project.pbxproj
+++ b/TrackMyCafe.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		3B4B6CEF4F19020CA61E542F /* CreatePurchaseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD07469C63E32CAA6902B68 /* CreatePurchaseViewModel.swift */; };
 		3F2453C445B3640596D717FF /* InventoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B162B8F1542975346D60E96C /* InventoryService.swift */; };
 		41B28220EBF9A67574D03A16 /* FIRInventoryAdjustmentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FD1F21E33AB28573D226D6 /* FIRInventoryAdjustmentModel.swift */; };
+		41E971F257A830E4ACC7257D /* SettingListViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9413DC32AFFD1886295E5F /* SettingListViewController+Extension.swift */; };
 		4977F65AE7E611D0F5DEC14A /* IncomeAggregationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E5355EAC70CBDE5DF12E7B /* IncomeAggregationService.swift */; };
 		4A28A93925922CA1446419A5 /* OpexCategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176C8E4B11E5920B65578186 /* OpexCategoryModel.swift */; };
 		4C43FC8B94A23DAEB82BC5D4 /* FIROpexExpenseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B339E6943346E259FE073530 /* FIROpexExpenseModel.swift */; };
@@ -60,6 +61,7 @@
 		8085320D6FEC24703DD60FA6 /* Pods_TrackMyCafe_Dev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6416781F69E5445B42ECEB9D /* Pods_TrackMyCafe_Dev.framework */; };
 		8105DEE93A100D479952119C /* CreatePurchaseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD07469C63E32CAA6902B68 /* CreatePurchaseViewModel.swift */; };
 		8326DB2EA2AF252E03E3D6FB /* IncomeAggregationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E5355EAC70CBDE5DF12E7B /* IncomeAggregationService.swift */; };
+		856C77E55B7076912583B40B /* SettingListViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9413DC32AFFD1886295E5F /* SettingListViewController+Extension.swift */; };
 		86E11A31F94CE29A805E2DC7 /* InventoryContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA632FB7E61C8ABEAD0817E /* InventoryContainerViewController.swift */; };
 		87E09BE852A5451015EFEE24 /* PurchaseListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58301BF0EA0AA4AD13300E91 /* PurchaseListViewModel.swift */; };
 		8B2F9562AB8F0E57B3BF30EA /* StockListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FB0242092853861442A8F6 /* StockListViewController.swift */; };
@@ -652,6 +654,7 @@
 		F3FED52E2EEF2FEB00C24082 /* TPInAppReceipt-Objc in Frameworks */ = {isa = PBXBuildFile; productRef = F3FED52D2EEF2FEB00C24082 /* TPInAppReceipt-Objc */; };
 		F3FED5302EEF300900C24082 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = F3FED52F2EEF300900C24082 /* Kingfisher */; };
 		F713CE57999390D4242D7E6B /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 64CAD59EFB3D9EDE181639AD /* InfoPlist.strings */; };
+		FB42220CC9DA241188396827 /* SettingListViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9413DC32AFFD1886295E5F /* SettingListViewController+Extension.swift */; };
 		FCE96ED35C3D3D05C4F36138 /* CostsTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7406B8CE84FF5691929D145 /* CostsTabViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -688,6 +691,7 @@
 		A4BB80BCD60550E2E948B3B8 /* StockListViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StockListViewModel.swift; sourceTree = "<group>"; };
 		B162B8F1542975346D60E96C /* InventoryService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InventoryService.swift; sourceTree = "<group>"; };
 		B339E6943346E259FE073530 /* FIROpexExpenseModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FIROpexExpenseModel.swift; sourceTree = "<group>"; };
+		BE9413DC32AFFD1886295E5F /* SettingListViewController+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SettingListViewController+Extension.swift"; sourceTree = "<group>"; };
 		C7406B8CE84FF5691929D145 /* CostsTabViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CostsTabViewController.swift; sourceTree = "<group>"; };
 		CCDA06ECE1F0D21E58F60FC0 /* Pods-TrackMyCafe Prod.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TrackMyCafe Prod.release.xcconfig"; path = "Target Support Files/Pods-TrackMyCafe Prod/Pods-TrackMyCafe Prod.release.xcconfig"; sourceTree = "<group>"; };
 		D5FB0242092853861442A8F6 /* StockListViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StockListViewController.swift; sourceTree = "<group>"; };
@@ -878,11 +882,61 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		F324E60A2F486E99003A7469 /* Selection */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Selection; sourceTree = "<group>"; };
-		F3299A932F35065600EA6532 /* Cells */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Cells; sourceTree = "<group>"; };
-		F35E91AE2F49D7DA0050EB4A /* ProductCategories */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ProductCategories; sourceTree = "<group>"; };
-		F362781C2EE5508D00A69CFE /* Home */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Home; sourceTree = "<group>"; };
-		F3B7A8342EE220F0007BF216 /* Onboarding */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Onboarding; sourceTree = "<group>"; };
+		F324E60A2F486E99003A7469 /* Selection */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Selection;
+			sourceTree = "<group>";
+		};
+		F3299A932F35065600EA6532 /* Cells */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
+		F35E91AE2F49D7DA0050EB4A /* ProductCategories */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = ProductCategories;
+			sourceTree = "<group>";
+		};
+		F362781C2EE5508D00A69CFE /* Home */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		F3B7A8342EE220F0007BF216 /* Onboarding */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Onboarding;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1595,6 +1649,7 @@
 			children = (
 				F3821C7827EA0187006D40FC /* Cells */,
 				F39A5338273252B800C8F2D3 /* SettingListViewController.swift */,
+				BE9413DC32AFFD1886295E5F /* SettingListViewController+Extension.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2804,6 +2859,7 @@
 				D6BB3356F32A4C11CFDCC6E2 /* IncomeAggregationService.swift in Sources */,
 				616D0BCC9656EF676C7EDBB2 /* FinanceAggregationService.swift in Sources */,
 				0E980A2C21B9CC72F4516FAC /* PaddedTextField.swift in Sources */,
+				FB42220CC9DA241188396827 /* SettingListViewController+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2993,6 +3049,7 @@
 				8326DB2EA2AF252E03E3D6FB /* IncomeAggregationService.swift in Sources */,
 				C607F96C23948CDC042DF233 /* FinanceAggregationService.swift in Sources */,
 				66D52AFA3785F04F868BEBFE /* PaddedTextField.swift in Sources */,
+				856C77E55B7076912583B40B /* SettingListViewController+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3182,6 +3239,7 @@
 				4977F65AE7E611D0F5DEC14A /* IncomeAggregationService.swift in Sources */,
 				77B686EC2C65B30FAD473CD3 /* FinanceAggregationService.swift in Sources */,
 				552467AE60F8B2EDD9769D5F /* PaddedTextField.swift in Sources */,
+				41E971F257A830E4ACC7257D /* SettingListViewController+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TrackMyCafe/Application/SceneDelegate.swift
+++ b/TrackMyCafe/Application/SceneDelegate.swift
@@ -83,18 +83,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, Loggable {
     logger.info("Current system language code: \(Locale.current.languageCode ?? "N/A")")
     window = UIWindow(windowScene: windowScene)
 
-    let isValidSession = UserSession.current.restore()
-    // Always check for online session
-    if !isValidSession || Auth.auth().currentUser == nil {
-        // Якщо сесія не дійсна або користувач не аутентифікований, переходимо на екран входу
-        let signInController = SignInController()
-        let navigationController = UINavigationController(rootViewController: signInController)
-        navigationController.setNavigationBarHidden(true, animated: false)
-        window?.rootViewController = navigationController
-    } else {
-        // Якщо сесія дійсна, переходимо на головний екран додатку
-        window?.rootViewController = MainTabBarController()
-    }
+    start()
 
     window?.makeKeyAndVisible()
 
@@ -107,6 +96,21 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, Loggable {
     #if canImport(Instructions)
       OnboardingManager.shared.configure(driver: InstructionsDriver())
     #endif
+  }
+
+  func start() {
+    let isValidSession = UserSession.current.restore()
+    // Always check for online session
+    if !isValidSession || Auth.auth().currentUser == nil {
+        // Якщо сесія не дійсна або користувач не аутентифікований, переходимо на екран входу
+        let signInController = SignInController()
+        let navigationController = UINavigationController(rootViewController: signInController)
+        navigationController.setNavigationBarHidden(true, animated: false)
+        window?.rootViewController = navigationController
+    } else {
+        // Якщо сесія дійсна, переходимо на головний екран додатку
+        window?.rootViewController = MainTabBarController()
+    }
   }
 
   func set(root controller: UIViewController) {

--- a/TrackMyCafe/Resources/Localization/en.lproj/Global.strings
+++ b/TrackMyCafe/Resources/Localization/en.lproj/Global.strings
@@ -142,6 +142,17 @@
 "writeToDeveloper" = "Write to Developer";
 "general" = "General";
 "priceList" = "Product Catalog";
+
+// MARK: - Account Deletion
+"deleteAccount" = "Delete Account";
+"account" = "Account";
+"deleteAccountFooter" = "Deleting your account is permanent and cannot be undone. All your data will be erased.";
+"deleteAccountTitle" = "Delete Account?";
+"deleteAccountMessage" = "Are you sure you want to delete your account? This action cannot be undone.";
+"deleting" = "Deleting...";
+"authenticationRequired" = "Authentication Required";
+"reauthMessage" = "For security reasons, please log in again to delete your account.";
+
 "receiptTypes" = "Receipt Types";
 "ingredients" = "Ingredients";
 "seedTestData" = "Seed Test Data";

--- a/TrackMyCafe/Resources/Localization/uk.lproj/Global.strings
+++ b/TrackMyCafe/Resources/Localization/uk.lproj/Global.strings
@@ -142,6 +142,17 @@
 "writeToDeveloper" = "Написати розробнику";
 "general" = "Загальні";
 "priceList" = "Каталог товарів";
+
+// MARK: - Account Deletion
+"deleteAccount" = "Видалити акаунт";
+"account" = "Акаунт";
+"deleteAccountFooter" = "Видалення вашого акаунту є незворотнім і не може бути скасоване. Всі ваші дані будуть стерті.";
+"deleteAccountTitle" = "Видалити акаунт?";
+"deleteAccountMessage" = "Ви впевнені, що хочете видалити свій акаунт? Цю дію неможливо скасувати.";
+"deleting" = "Видалення...";
+"authenticationRequired" = "Потрібна автентифікація";
+"reauthMessage" = "З міркувань безпеки, будь ласка, увійдіть знову, щоб видалити свій акаунт.";
+
 "receiptTypes" = "Типи чеків";
 "ingredients" = "Інгредієнти";
 "seedTestData" = "Заповнити тестовими даними";

--- a/TrackMyCafe/Services/FIR/FirestoreDatabaseService.swift
+++ b/TrackMyCafe/Services/FIR/FirestoreDatabaseService.swift
@@ -12,14 +12,14 @@ import FirebaseFirestoreSwift
 import os.log
 
 class FirestoreDatabaseService: FirestoreDB, Loggable {
-    
+
     @Published var errorMessage: String?
-    
+
     private let db = Firestore.firestore()
     static let shared = FirestoreDatabaseService()
     private let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier!, category: "FirestoreDatabaseService")
-    
+
     // MARK: - Lifecycle
     private init() {
         let settings = FirestoreSettings()
@@ -27,9 +27,9 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
         settings.cacheSettings = PersistentCacheSettings()
         db.settings = settings
     }
-    
+
     // MARK: - User-specific Operations
-    
+
     private func getUserCollection(collection: String) -> CollectionReference? {
         guard let userId = Auth.auth().currentUser?.uid else {
             logger.error("No authenticated user found")
@@ -38,9 +38,9 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
         return db.collection(FirebaseCollections.users).document(userId).collection(
             collection)
     }
-    
+
     // MARK: - Generic CRUD Operations
-    
+
     func create<T: Encodable>(
         firModel: T, collection: String, completion: @escaping (Result<String, Error>) -> Void
     ) {
@@ -63,7 +63,7 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             completion(.failure(error))
         }
     }
-    
+
     func fetchObjectById<T: Decodable>(
         ofType: T.Type, collection: String, id: String, completion: @escaping (Result<T, Error>) -> Void
     ) {
@@ -75,7 +75,7 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
                         userInfo: [NSLocalizedDescriptionKey: "No authenticated user found"])))
             return
         }
-        
+
         guard !id.isEmpty else {
             logger.error("fetchObjectById called with empty ID for collection: \(collection)")
             completion(
@@ -85,7 +85,7 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
                         userInfo: [NSLocalizedDescriptionKey: "Document ID cannot be empty"])))
             return
         }
-        
+
         userCollection.document(id).getDocument { [self] document, error in
             if let error = error {
                 self.logger.error("Error getting document: \(error.localizedDescription)")
@@ -108,7 +108,7 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             }
         }
     }
-    
+
     func read<T: Decodable>(
         collection: String, firModel: T.Type,
         completion: @escaping (Result<[(documentId: String, T)], Error>) -> Void
@@ -121,7 +121,7 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
                         userInfo: [NSLocalizedDescriptionKey: "No authenticated user found"])))
             return
         }
-        
+
         userCollection.getDocuments { [self] querySnapshot, error in
             if let error = error {
                 self.logger.error("Error getting documents: \(error.localizedDescription)")
@@ -144,7 +144,7 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             }
         }
     }
-    
+
     func update<T: Encodable>(
         firModel: T, collection: String, documentId: String,
         completion: @escaping (Result<Void, Error>) -> Void
@@ -166,7 +166,7 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             completion(.failure(error))
         }
     }
-    
+
     func delete(
         collection: String, documentId: String, completion: @escaping (Result<Void, Error>) -> Void
     ) {
@@ -188,9 +188,9 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             }
         }
     }
-    
+
     // MARK: - CRUD Operations for Products
-    
+
     func createProduct(
         product: FIRProductsPriceModel, completion: @escaping (Result<Bool, Error>) -> Void
     ) {
@@ -203,7 +203,7 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             }
         }
     }
-    
+
     func readProducts(
         completion: @escaping (Result<[(documentId: String, FIRProductsPriceModel)], Error>) -> Void
     ) {
@@ -211,9 +211,9 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             collection: FirebaseCollections.productsPrice, firModel: FIRProductsPriceModel.self,
             completion: completion)
     }
-    
+
     // MARK: - CRUD Operations for Types
-    
+
     func createType(type: FIRTypeModel, completion: @escaping (Result<Bool, Error>) -> Void) {
         create(firModel: type, collection: FirebaseCollections.types) { result in
             switch result {
@@ -224,7 +224,7 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             }
         }
     }
-    
+
     func readTypes(
         completion: @escaping (Result<[(documentId: String, FIRTypeModel)], Error>) -> Void
     ) {
@@ -232,11 +232,11 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             collection: FirebaseCollections.types, firModel: FIRTypeModel.self,
             completion: completion)
     }
-    
+
     // MARK: - CRUD Operations for Costs (Deprecated, handled via OpexExpenseModel)
-    
+
     // MARK: - CRUD Operations for Orders
-    
+
     func createOrdersOfProducts(
         order: FIRProductModel, completion: @escaping (Result<Bool, Error>) -> Void
     ) {
@@ -249,7 +249,7 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             }
         }
     }
-    
+
     func readOrdersOfProducts(
         completion: @escaping (Result<[(documentId: String, FIRProductModel)], Error>) -> Void
     ) {
@@ -257,14 +257,14 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             collection: FirebaseCollections.productOfOrders, firModel: FIRProductModel.self,
             completion: completion)
     }
-    
+
     // MARK: - CRUD Operations for Orders
-    
+
     func createOrder(order: FIROrderModel, completion: @escaping (Result<String, Error>) -> Void) {
         create(
             firModel: order, collection: FirebaseCollections.orders, completion: completion)
     }
-    
+
     func readOrder(
         completion: @escaping (Result<[(documentId: String, FIROrderModel)], Error>) -> Void
     ) {
@@ -272,33 +272,33 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             collection: FirebaseCollections.orders, firModel: FIROrderModel.self,
             completion: completion)
     }
-    
+
     // MARK: - Delete All Data
-    
+
     private func deleteCollection(collection: String, batchSize: Int = 400, completion: @escaping (Error?) -> Void) {
         guard let userCollection = getUserCollection(collection: collection) else {
             completion(nil)
             return
         }
-        
+
         userCollection.limit(to: batchSize).getDocuments { [weak self] querySnapshot, error in
             guard let self = self else { return }
-            
+
             if let error = error {
                 completion(error)
                 return
             }
-            
+
             guard let documents = querySnapshot?.documents, !documents.isEmpty else {
                 completion(nil)
                 return
             }
-            
+
             let batch = self.db.batch()
             for document in documents {
                 batch.deleteDocument(document.reference)
             }
-            
+
             batch.commit { error in
                 if let error = error {
                     completion(error)
@@ -308,24 +308,29 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             }
         }
     }
-    
+
     func deleteAllData(completion: @escaping (Bool) -> Void) {
         let collections = [
-            FirebaseCollections.productsPrice, FirebaseCollections.types,
+            FirebaseCollections.productsPrice,
+            FirebaseCollections.types,
             FirebaseCollections.orders,
             FirebaseCollections.productOfOrders,
             FirebaseCollections.inventoryAdjustments,
             FirebaseCollections.opexExpenses,
             FirebaseCollections.ingredients,
-            FirebaseCollections.purchases
+            FirebaseCollections.purchases,
+            FirebaseCollections.productCategories,
+            FirebaseCollections.costs,
+            FirebaseCollections.technicians,
+            FirebaseCollections.admins
         ]
         let dispatchGroup = DispatchGroup()
         var overallSuccess = true
-        
+
         for collection in collections {
             dispatchGroup.enter()
             self.logger.info("dispatchGroup.enter \(collection)")
-            
+
             deleteCollection(collection: collection) { [weak self] error in
                 if let error = error {
                     self?.logger.error(
@@ -338,13 +343,59 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
                 dispatchGroup.leave()
             }
         }
-        
+
         dispatchGroup.notify(queue: .main) {
             self.logger.info("All data deleted successfully from Firestore")
             completion(overallSuccess)
         }
     }
-    
+
+    func deleteUserAndRoles(completion: @escaping (Result<Void, Error>) -> Void) {
+        guard let userId = Auth.auth().currentUser?.uid else {
+            completion(.failure(NSError(domain: "NoUser", code: 0, userInfo: [NSLocalizedDescriptionKey: "No authenticated user found"])))
+            return
+        }
+
+        deleteAllData { [weak self] success in
+            guard let self = self else { return }
+            if !success {
+                completion(.failure(NSError(domain: "DeleteDataError", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to delete user data"])))
+                return
+            }
+
+            // Delete roles
+            self.deleteRoles(userId: userId) { error in
+                if let error = error {
+                    completion(.failure(error))
+                    return
+                }
+
+                // Delete user document
+                self.db.collection(FirebaseCollections.users).document(userId).delete { error in
+                    if let error = error {
+                        completion(.failure(error))
+                    } else {
+                        completion(.success(()))
+                    }
+                }
+            }
+        }
+    }
+
+    private func deleteRoles(userId: String, completion: @escaping (Error?) -> Void) {
+        db.collection(FirebaseCollections.roles).whereField(FirebaseFields.userRef, isEqualTo: userId).getDocuments { [weak self] snapshot, error in
+            guard let self = self else { completion(error); return }
+            if let error = error { completion(error); return }
+
+            let batch = self.db.batch()
+            snapshot?.documents.forEach { batch.deleteDocument($0.reference) }
+
+            batch.commit { error in
+                completion(error)
+            }
+        }
+    }
+
     static func getRoles(_ email: String, completion: @escaping ([RoleConfig]?) -> Void) {
         FirestoreDatabaseService.shared.db.collection(FirebaseCollections.roles)
         //db.collection("roles")
@@ -363,7 +414,7 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
                 completion(roles)
             }
     }
-    
+
     static func getTechRoles(_ email: String, completion: @escaping ([RoleConfig]?) -> Void) {
         FirestoreDatabaseService.shared.db.collection(FirebaseCollections.roles)
         //db.collection("roles")
@@ -383,7 +434,7 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
                 completion(roles)
             }
     }
-    
+
     func checkData(_ key: String?, completion: @escaping (Bool) -> Void) {
         guard let key = key else {
             completion(false)
@@ -402,7 +453,7 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
                 completion(document?.exists ?? false)
             }
     }
-    
+
     func createNewCafe(
         _ id: String, _ email: String, _ completion: @escaping (RoleConfig?, Bool) -> Void
     ) {
@@ -413,27 +464,27 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             completion(nil, false)
             return
         }
-        
+
         // Створення даних користувача
         guard let userData = userData(userKey, id, email) else {
             completion(nil, false)
             return
         }
-        
+
         // Створення даних ролі
         let roleKey = db.collection(FirebaseCollections.roles).document().documentID
         let role = RoleConfig(
             ref: roleKey, email: email, dataRef: userKey, userRef: userKey, role: Role.administrator,
             onlineVersion: true)
-        
+
         let roles = [role]  // Створюємо масив з однією роллю
-        
+
         // Використання транзакції для одночасного створення документів у колекціях `users` та `roles`
         let batch = db.batch()
-        
+
         let userRef = db.collection(FirebaseCollections.users).document(userKey)
         batch.setData(userData, forDocument: userRef)
-        
+
         // Додавання ролей до колекції `roles`
         roles.forEach { role in
             let roleRef = FirestoreDatabaseService.shared.db.collection(FirebaseCollections.roles)
@@ -443,34 +494,34 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             roleData[FirebaseFields.userRef] = userKey
             batch.setData(roleData, forDocument: roleRef)
         }
-        
+
         // Коміт транзакції
         batch.commit { error in
             completion(role, error == nil)
         }
     }
-    
+
     func createNewUser(
         _ roles: [RoleConfig], _ id: String, _ email: String, _ completion: @escaping (Bool) -> Void
     ) {
         // Створення унікального ідентифікатора для користувача
         let userKey = FirestoreDatabaseService.shared.db.collection(FirebaseCollections.users)
             .document().documentID
-        
+
         // Створення даних користувача
         guard let userData = userData(userKey, id, email) else {
             completion(false)
             return
         }
-        
+
         // Використання транзакції для одночасного створення документів у колекціях `users` та `roles`
         let batch = FirestoreDatabaseService.shared.db.batch()
-        
+
         // Додавання користувача до колекції `users`
         let userRef = FirestoreDatabaseService.shared.db.collection(FirebaseCollections.users).document(
             userKey)
         batch.setData(userData, forDocument: userRef)
-        
+
         // Додавання ролей до колекції `roles`
         roles.forEach { role in
             let roleRef = FirestoreDatabaseService.shared.db.collection(FirebaseCollections.roles)
@@ -480,15 +531,15 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             roleData[FirebaseFields.userRef] = userKey
             batch.setData(roleData, forDocument: roleRef)
         }
-        
+
         // Коміт транзакції
         batch.commit { error in
             completion(error == nil)
         }
     }
-    
+
     private func userData(_ userKey: String, _ id: String, _ email: String) -> [String: Any]? {
-        
+
         var userValue: [String: Any] = [
             FirebaseFields.uid: id,
             FirebaseFields.firebaseRef: userKey,
@@ -504,43 +555,43 @@ class FirestoreDatabaseService: FirestoreDB, Loggable {
             FirebaseFields.avatarUrl: "",
             FirebaseFields.avatarThumbnailUrl: "",
         ]
-        
+
         let isUkrainian = Locale.current.languageCode == "uk"
         let defaultCurrencyName = isUkrainian ? DefaultValues.currencyName : DefaultValues.dollarName
         let defaultCurrencySymbol = isUkrainian ? DefaultValues.currencySymbol : DefaultValues.dollarSymbol
         userValue["Settings"] = Settings(
             currencyName: defaultCurrencyName, currencySymbol: defaultCurrencySymbol
         ).forDatabase()
-        
+
         return userValue
     }
-    
+
     static func updateAdmin(_ item: Admin, completion: @escaping (Bool) -> Void) {
         let db = Firestore.firestore()
         let adminRef = db.collection(FirebaseCollections.admins).document(item.firebaseRef)  // assuming `item.firebaseRef` is the document ID
-        
+
         adminRef.updateData(item.forDatabase()) { error in
             completion(error == nil)
         }
     }
-    
+
     static func deleteTechnician(_ item: Technician, completion: @escaping (Bool) -> Void) {
         getTechRoles(item.email.trimmed.lowercased()) { (roles) in
             let batch = Firestore.firestore().batch()
-            
+
             roles?.forEach { role in
                 let roleRef = Firestore.firestore().collection(FirebaseCollections.roles).document(
                     role.firebaseRef)
                 batch.deleteDocument(roleRef)
             }
-            
+
             let userRef = Firestore.firestore().collection(FirebaseCollections.users)
                 .document(UserSession.current.masterUserRef)
                 .collection(item.ref.rawValue)
                 .document(item.firebaseRef)
-            
+
             batch.updateData([FirebaseFields.enabled: false], forDocument: userRef)
-            
+
             batch.commit { error in
                 completion(error == nil)
             }

--- a/TrackMyCafe/View Layer/Flow/Settings/SettingList/View/SettingListViewController+Extension.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/SettingList/View/SettingListViewController+Extension.swift
@@ -1,0 +1,75 @@
+//
+//  SettingListViewController+Extension.swift
+//  TrackMyCafe
+//
+//  Created by AI Assistant on 29.01.2026.
+//
+
+import UIKit
+import FirebaseAuth
+import SVProgressHUD
+
+extension SettingListViewController {
+
+    func showDeleteAccountConfirmation() {
+        PopupFactory.showDestructivePopup(
+            title: R.string.global.deleteAccountTitle(),
+            description: R.string.global.deleteAccountMessage(),
+            buttonTitle: R.string.global.delete()
+        ) {
+            self.performAccountDeletion()
+        }
+    }
+
+    private func performAccountDeletion() {
+        SVProgressHUD.show(withStatus: R.string.global.deleting())
+
+        FirestoreDatabaseService.shared.deleteUserAndRoles { [weak self] result in
+            switch result {
+            case .success:
+                Auth.auth().currentUser?.delete { error in
+                    SVProgressHUD.dismiss()
+                    if let error = error as NSError? {
+                        // Requires recent login
+                        if error.code == AuthErrorCode.requiresRecentLogin.rawValue {
+                            self?.showReauthAlert()
+                        } else {
+                            self?.showErrorAlert(message: error.localizedDescription)
+                        }
+                    } else {
+                        // Success
+                        UserSession.logOut()
+                        self?.navigateToLogin()
+                    }
+                }
+            case .failure(let error):
+                SVProgressHUD.dismiss()
+                self?.showErrorAlert(message: error.localizedDescription)
+            }
+        }
+    }
+
+    private func showReauthAlert() {
+        PopupFactory.showPopup(
+            title: R.string.global.authenticationRequired(),
+            description: R.string.global.reauthMessage(),
+            buttonTitle: R.string.global.actionOk()
+        ) {
+            UserSession.logOut()
+            self.navigateToLogin()
+        }
+    }
+
+    private func showErrorAlert(message: String) {
+        PopupFactory.showPopup(
+            title: R.string.global.error(),
+            description: message
+        )
+    }
+
+    private func navigateToLogin() {
+        if let sceneDelegate = self.view.window?.windowScene?.delegate as? SceneDelegate {
+            sceneDelegate.start()
+        }
+    }
+}

--- a/TrackMyCafe/View Layer/Flow/Settings/SettingList/View/SettingListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/SettingList/View/SettingListViewController.swift
@@ -281,6 +281,14 @@ class SettingListViewController: UIViewController, UITableViewDelegate, UITableV
                 ) {
                     self.presentFeedbackEmail()
                 }),
+            .staticCell(
+                model: SettingsStaticOption(
+                    title: R.string.global.deleteAccount(),
+                    icon: UIImage(systemName: "trash.fill"),
+                    iconBackgroundColor: .systemRed
+                ) {
+                    self.showDeleteAccountConfirmation()
+                }),
         ]
 
         if DemoDataManager.shared.isDemoDataPresent {

--- a/TrackMyCafe/View Layer/UI/Popup/PopupFactory.swift
+++ b/TrackMyCafe/View Layer/UI/Popup/PopupFactory.swift
@@ -266,6 +266,75 @@ class PopupFactory {
         let contentView = EKAlertMessageView(with: alertMessage)
         SwiftEntryKit.display(entry: contentView, using: PopupFactory.presentAttributes)
     }
+
+    static func showDestructivePopup(
+        title: String, description: String, buttonTitle: String, buttonAction: @escaping () -> Void
+    ) {
+        let kHighlightColor = EKColor(rgb: 0x424242)
+
+        let title = EKProperty.LabelContent(
+            text: title,
+            style: .init(
+                font: .systemFont(ofSize: 17, weight: .medium),
+                color: EKColor(UIColor.label),
+                alignment: .center
+            )
+        )
+
+        let text = description
+        let description = EKProperty.LabelContent(
+            text: text,
+            style: .init(
+                font: .systemFont(ofSize: 14),
+                color: EKColor(UIColor.secondaryLabel),
+                alignment: .center
+            )
+        )
+
+        let simpleMessage = EKSimpleMessage(title: title, description: description)
+
+        let buttonFont = UIFont.systemFont(ofSize: 16, weight: .medium)
+
+        let destructiveButtonLabelStyle = EKProperty.LabelStyle(
+            font: buttonFont,
+            color: EKColor(.systemRed)
+        )
+        let cancelButtonLabelStyle = EKProperty.LabelStyle(
+            font: buttonFont,
+            color: EKColor(.systemBlue)
+        )
+
+        let actionButton = EKProperty.ButtonContent(
+            label: EKProperty.LabelContent(text: buttonTitle, style: destructiveButtonLabelStyle),
+            backgroundColor: .clear,
+            highlightedBackgroundColor: kHighlightColor.with(alpha: 0.05)
+        ) {
+            buttonAction()
+            SwiftEntryKit.dismiss()
+        }
+
+        let closeButton = EKProperty.ButtonContent(
+            label: EKProperty.LabelContent(
+                text: R.string.global.cancel(), style: cancelButtonLabelStyle),
+            backgroundColor: .clear,
+            highlightedBackgroundColor: kHighlightColor.with(alpha: 0.05)
+        ) {
+            SwiftEntryKit.dismiss()
+        }
+
+        let buttonsBarContent = EKProperty.ButtonBarContent(
+            with: [closeButton, actionButton],
+            separatorColor: EKColor(red: 230, green: 230, blue: 230),
+            horizontalDistributionThreshold: 2,
+            expandAnimatedly: false
+        )
+        let alertMessage = EKAlertMessage(
+            simpleMessage: simpleMessage,
+            buttonBarContent: buttonsBarContent
+        )
+        let contentView = EKAlertMessageView(with: alertMessage)
+        SwiftEntryKit.display(entry: contentView, using: PopupFactory.presentAttributes)
+    }
 }
 
 private class OrderModePopupView: UIView {


### PR DESCRIPTION
# Account Deletion Feature

This PR implements the functionality for users to delete their account directly from the app.

## Changes

- **Backend (`FirestoreDatabaseService.swift`)**:
  - Added `deleteUserAndRoles` method to recursively delete all user data (subcollections, roles, and user document).
  - Updated `deleteAllData` to include all relevant collections (`productCategories`, `costs`, `technicians`, `admins`, etc.).

- **UI (`SettingListViewController.swift` & Extension)**:
  - Added a new **"Account"** section in Settings.
  - Added **"Delete Account"** button with destructive styling.
  - Implemented confirmation alert using `PopupFactory`.
  - Added handling for `requiresRecentLogin` error (prompts re-authentication).

- **Localization (`Global.strings`)**:
  - Added English and Ukrainian translations for account deletion flow.

- **Navigation (`SceneDelegate.swift`)**:
  - Refactored app startup logic into `start()` method to support re-initialization after account deletion.

## Validation

- Verified that all user data is removed from Firestore.
- Verified that Firebase Auth user is deleted.
- Verified that the app logs out and navigates to the login screen upon success.
