### PR TITLE
fix(onboarding): coach marks auto-scroll + order UI insets

### DIFF
--- a/TrackMyCafe/View Layer/Flow/Onboarding/View/OnboardingViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Onboarding/View/OnboardingViewController.swift
@@ -88,7 +88,9 @@ final class OnboardingViewController: UIViewController {
         pageControl.centerXToSuperview()
         pageControl.bottomToTop(of: nextButton, offset: -20)
 
-        nextButton.edgesToSuperview(excluding: .top, insets: .bottom(50) + .left(24) + .right(24))
+        nextButton.leftToSuperview(offset: 24)
+        nextButton.rightToSuperview(offset: -24)
+        nextButton.bottomToSuperview(offset: -20, usingSafeArea: true)
         nextButton.height(50)
     }
 

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/Cells/OrderTableViewCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/Cells/OrderTableViewCell.swift
@@ -9,149 +9,160 @@ import UIKit
 
 class OrderTableViewCell: UITableViewCell {
 
-  let backgroundViewCell: UIView = {
-    let view = UIView()
-    view.backgroundColor = UIColor.TableView.cellBackground
-    view.layer.cornerRadius = 10
-    view.translatesAutoresizingMaskIntoConstraints = false
+    let backgroundViewCell: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.TableView.cellBackground
+        view.layer.cornerRadius = 10
+        view.translatesAutoresizingMaskIntoConstraints = false
 
-    return view
-  }()
+        return view
+    }()
 
-  private let separatorView: UIView = {
-    let view = UIView()
-    view.backgroundColor = UIColor.separator
-    view.translatesAutoresizingMaskIntoConstraints = false
-    return view
-  }()
+    private let separatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.separator
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
 
-  let productLabel: UILabel = {
-    let label = UILabel()
-    label.text = ""
-    label.translatesAutoresizingMaskIntoConstraints = false
-    label.textColor = UIColor.TableView.cellLabel
-    label.applyDynamic(Typography.body)
-    label.numberOfLines = 1
-    label.lineBreakMode = .byTruncatingTail
+    let productLabel: UILabel = {
+        let label = UILabel()
+        label.text = ""
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = UIColor.TableView.cellLabel
+        label.applyDynamic(Typography.body)
+        label.numberOfLines = 1
+        label.lineBreakMode = .byTruncatingTail
 
-    return label
-  }()
+        return label
+    }()
 
-  let quantityLabel: UILabel = {
-    let label = UILabel()
-    label.text = ""
-    label.translatesAutoresizingMaskIntoConstraints = false
-    label.textColor = UIColor.TableView.cellLabel
-    label.applyDynamic(Typography.body)
+    let quantityLabel: UILabel = {
+        let label = UILabel()
+        label.text = ""
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = UIColor.TableView.cellLabel
+        label.applyDynamic(Typography.body)
 
-    return label
-  }()
+        return label
+    }()
 
-  let productStepper: UIStepper = {
-    let stepper = UIStepper()
-    stepper.translatesAutoresizingMaskIntoConstraints = false
+    let productStepper: UIStepper = {
+        let stepper = UIStepper()
+        stepper.translatesAutoresizingMaskIntoConstraints = false
 
-    return stepper
-  }()
+        return stepper
+    }()
 
-  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-    super.init(style: style, reuseIdentifier: reuseIdentifier)
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
 
-    self.backgroundColor = UIColor.Main.background
-    setConstraints()
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-
-  weak var viewModel: ProductListItemViewModelType? {
-    willSet(viewModel) {
-      guard let viewModel = viewModel else { return }
-      productLabel.text = viewModel.productLabel
-      quantityLabel.text = viewModel.quantityLabel
-      productStepper.value = viewModel.productStepperValue
-      productStepper.tag = viewModel.productStepperTag
-    }
-  }
-
-  func setConstraints() {
-
-    self.addSubview(backgroundViewCell)
-    NSLayoutConstraint.activate([
-      backgroundViewCell.topAnchor.constraint(equalTo: self.topAnchor, constant: 0),
-      backgroundViewCell.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: UIConstants.standardPadding),
-      backgroundViewCell.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -UIConstants.standardPadding),
-      backgroundViewCell.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -1),
-    ])
-
-    self.addSubview(productLabel)
-    NSLayoutConstraint.activate([
-      productLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-      productLabel.leadingAnchor.constraint(
-        equalTo: backgroundViewCell.leadingAnchor, constant: 12),
-    ])
-
-    self.contentView.addSubview(productStepper)
-    NSLayoutConstraint.activate([
-      productStepper.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-      productStepper.trailingAnchor.constraint(
-        equalTo: backgroundViewCell.trailingAnchor, constant: -12),
-    ])
-
-    self.contentView.addSubview(quantityLabel)
-    NSLayoutConstraint.activate([
-      quantityLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-      quantityLabel.trailingAnchor.constraint(equalTo: productStepper.leadingAnchor, constant: -12),
-      productLabel.trailingAnchor.constraint(lessThanOrEqualTo: quantityLabel.leadingAnchor, constant: -8),
-    ])
-
-    backgroundViewCell.addSubview(separatorView)
-    NSLayoutConstraint.activate([
-      separatorView.leadingAnchor.constraint(equalTo: backgroundViewCell.leadingAnchor, constant: 12),
-      separatorView.trailingAnchor.constraint(equalTo: backgroundViewCell.trailingAnchor, constant: -12),
-      separatorView.bottomAnchor.constraint(equalTo: backgroundViewCell.bottomAnchor),
-      separatorView.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale),
-    ])
-
-    productLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-    quantityLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
-    quantityLabel.setContentHuggingPriority(.required, for: .horizontal)
-    productStepper.setContentCompressionResistancePriority(.required, for: .horizontal)
-  }
-
-  func applyListStyle(row: Int, totalRows: Int) {
-    let radius: CGFloat = 12
-    backgroundViewCell.layer.masksToBounds = true
-
-    if totalRows <= 1 {
-      backgroundViewCell.layer.cornerRadius = radius
-      backgroundViewCell.layer.maskedCorners = [
-        .layerMinXMinYCorner, .layerMaxXMinYCorner,
-        .layerMinXMaxYCorner, .layerMaxXMaxYCorner,
-      ]
-      separatorView.isHidden = true
-      return
+        self.backgroundColor = UIColor.Main.background
+        directionalLayoutMargins = .zero
+        contentView.directionalLayoutMargins = .zero
+        preservesSuperviewLayoutMargins = true
+        contentView.preservesSuperviewLayoutMargins = true
+        setConstraints()
     }
 
-    let isFirst = row == 0
-    let isLast = row == totalRows - 1
-
-    if isFirst {
-      backgroundViewCell.layer.cornerRadius = radius
-      backgroundViewCell.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-      separatorView.isHidden = false
-    } else if isLast {
-      backgroundViewCell.layer.cornerRadius = radius
-      backgroundViewCell.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
-      separatorView.isHidden = true
-    } else {
-      backgroundViewCell.layer.cornerRadius = 0
-      backgroundViewCell.layer.maskedCorners = [
-        .layerMinXMinYCorner, .layerMaxXMinYCorner,
-        .layerMinXMaxYCorner, .layerMaxXMaxYCorner,
-      ]
-      separatorView.isHidden = false
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
-  }
+
+    weak var viewModel: ProductListItemViewModelType? {
+        willSet(viewModel) {
+            guard let viewModel = viewModel else { return }
+            productLabel.text = viewModel.productLabel
+            quantityLabel.text = viewModel.quantityLabel
+            productStepper.value = viewModel.productStepperValue
+            productStepper.tag = viewModel.productStepperTag
+        }
+    }
+
+    func setConstraints() {
+
+        contentView.addSubview(backgroundViewCell)
+        NSLayoutConstraint.activate([
+            backgroundViewCell.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 0),
+            backgroundViewCell.leadingAnchor.constraint(
+                equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            backgroundViewCell.trailingAnchor.constraint(
+                equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            backgroundViewCell.bottomAnchor.constraint(
+                equalTo: contentView.bottomAnchor, constant: -1),
+        ])
+
+        contentView.addSubview(productLabel)
+        NSLayoutConstraint.activate([
+            productLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            productLabel.leadingAnchor.constraint(
+                equalTo: backgroundViewCell.leadingAnchor, constant: 12),
+        ])
+
+        contentView.addSubview(productStepper)
+        NSLayoutConstraint.activate([
+            productStepper.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            productStepper.trailingAnchor.constraint(
+                equalTo: backgroundViewCell.trailingAnchor, constant: -12),
+        ])
+
+        contentView.addSubview(quantityLabel)
+        NSLayoutConstraint.activate([
+            quantityLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            quantityLabel.trailingAnchor.constraint(
+                equalTo: productStepper.leadingAnchor, constant: -12),
+            productLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: quantityLabel.leadingAnchor, constant: -8),
+        ])
+
+        backgroundViewCell.addSubview(separatorView)
+        NSLayoutConstraint.activate([
+            separatorView.leadingAnchor.constraint(
+                equalTo: backgroundViewCell.leadingAnchor, constant: 12),
+            separatorView.trailingAnchor.constraint(
+                equalTo: backgroundViewCell.trailingAnchor, constant: -12),
+            separatorView.bottomAnchor.constraint(equalTo: backgroundViewCell.bottomAnchor),
+            separatorView.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale),
+        ])
+
+        productLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        quantityLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        quantityLabel.setContentHuggingPriority(.required, for: .horizontal)
+        productStepper.setContentCompressionResistancePriority(.required, for: .horizontal)
+    }
+
+    func applyListStyle(row: Int, totalRows: Int) {
+        let radius: CGFloat = 12
+        backgroundViewCell.layer.masksToBounds = true
+
+        if totalRows <= 1 {
+            backgroundViewCell.layer.cornerRadius = radius
+            backgroundViewCell.layer.maskedCorners = [
+                .layerMinXMinYCorner, .layerMaxXMinYCorner,
+                .layerMinXMaxYCorner, .layerMaxXMaxYCorner,
+            ]
+            separatorView.isHidden = true
+            return
+        }
+
+        let isFirst = row == 0
+        let isLast = row == totalRows - 1
+
+        if isFirst {
+            backgroundViewCell.layer.cornerRadius = radius
+            backgroundViewCell.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+            separatorView.isHidden = false
+        } else if isLast {
+            backgroundViewCell.layer.cornerRadius = radius
+            backgroundViewCell.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+            separatorView.isHidden = true
+        } else {
+            backgroundViewCell.layer.cornerRadius = 0
+            backgroundViewCell.layer.maskedCorners = [
+                .layerMinXMinYCorner, .layerMaxXMinYCorner,
+                .layerMinXMaxYCorner, .layerMaxXMaxYCorner,
+            ]
+            separatorView.isHidden = false
+        }
+    }
 }

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderDetailsViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderDetailsViewController.swift
@@ -56,6 +56,10 @@ class OrderDetailsViewController: UIViewController, UITextFieldDelegate {
         tableView.dataSource = self
         tableView.backgroundColor = UIColor.Main.background
         tableView.separatorStyle = .none
+        tableView.preservesSuperviewLayoutMargins = true
+        tableView.directionalLayoutMargins = .zero
+        tableView.cellLayoutMarginsFollowReadableWidth = false
+        tableView.insetsContentViewsToSafeArea = false
         tableView.isScrollEnabled = false  // Disable scroll to avoid conflict with ScrollView
         tableView.accessibilityIdentifier = "productsTable"
         return tableView

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderReceiptPadViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderReceiptPadViewController.swift
@@ -231,6 +231,15 @@ final class OrderReceiptPadViewController: UIViewController, UITextFieldDelegate
         view.addSubview(tableView)
         tableView.register(OrderTableViewCell.self, forCellReuseIdentifier: CellIdentifiers.orderCell)
         tableView.delegate = self
+        tableView.preservesSuperviewLayoutMargins = true
+        tableView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: UIConstants.standardPadding,
+            bottom: 0,
+            trailing: UIConstants.standardPadding
+        )
+        tableView.cellLayoutMarginsFollowReadableWidth = false
+        tableView.insetsContentViewsToSafeArea = false
 
         configureDataSource()
     }

--- a/TrackMyCafe/View Layer/UI/Onboarding/InstructionsDriver.swift
+++ b/TrackMyCafe/View Layer/UI/Onboarding/InstructionsDriver.swift
@@ -1,145 +1,258 @@
 import UIKit
 
 #if canImport(Instructions)
-import Instructions
+    import Instructions
 
-final class InstructionsDriver: NSObject, CoachMarksDriver, CoachMarksControllerDataSource,
-                                CoachMarksControllerDelegate
-{
-    private let controller = CoachMarksController()
-    private weak var host: UIViewController?
-    private var steps: [OnboardingStepModel] = []
-    private var completion: (() -> Void)?
-
-    func present(
-        on host: UIViewController, steps: [OnboardingStepModel], completion: @escaping () -> Void
-    ) {
-        self.host = host
-        let filtered = steps.sorted { $0.order < $1.order }.filter {
-            resolveView(for: $0.targetKey) != nil
-        }
-        if filtered.isEmpty { return }
-        self.steps = filtered
-        self.completion = completion
-        controller.dataSource = self
-        controller.delegate = self
-        controller.start(in: .currentWindow(of: host))
-    }
-
-    func numberOfCoachMarks(for coachMarksController: CoachMarksController) -> Int {
-        steps.count
-    }
-
-    func coachMarksController(_ coachMarksController: CoachMarksController, coachMarkAt index: Int)
-    -> CoachMark
+    final class InstructionsDriver: NSObject, Loggable, CoachMarksDriver,
+        CoachMarksControllerDataSource,
+        CoachMarksControllerDelegate
     {
-        guard let view = resolveView(for: steps[index].targetKey) else {
-            return coachMarksController.helper.makeCoachMark()
-        }
+        private let controller = CoachMarksController()
+        private weak var host: UIViewController?
+        private var steps: [OnboardingStepModel] = []
+        private var completion: (() -> Void)?
 
-        // Scroll to view if needed BEFORE creating the coach mark
-        // Try to find a parent UIScrollView and scroll to the target view
-        var superview = view.superview
-        while let sView = superview {
-            if let scrollView = sView as? UIScrollView {
-                let frame = view.convert(view.bounds, to: scrollView)
-                let paddedFrame = frame.insetBy(dx: 0, dy: -40)
-                scrollView.scrollRectToVisible(paddedFrame, animated: false)
-                scrollView.layoutIfNeeded()
-                break
+        func present(
+            on host: UIViewController, steps: [OnboardingStepModel],
+            completion: @escaping () -> Void
+        ) {
+            self.host = host
+            let filtered = steps.sorted { $0.order < $1.order }.filter {
+                resolveView(for: $0.targetKey) != nil
             }
-            superview = sView.superview
+            if filtered.isEmpty { return }
+            self.steps = filtered
+            self.completion = completion
+            controller.dataSource = self
+            controller.delegate = self
+            controller.start(in: .currentWindow(of: host))
         }
 
-        var coachMark = coachMarksController.helper.makeCoachMark(for: view)
-        return coachMark
-    }
-
-    func coachMarksController(
-        _ coachMarksController: CoachMarksController,
-        coachMarkViewsAt index: Int,
-        madeFrom coachMark: CoachMark
-    ) -> (bodyView: UIView & CoachMarkBodyView, arrowView: (UIView & CoachMarkArrowView)?) {
-        let views = coachMarksController.helper.makeDefaultCoachViews(
-            withArrow: true, arrowOrientation: coachMark.arrowOrientation)
-        views.bodyView.hintLabel.text = steps[index].title + "\n" + steps[index].message
-        views.bodyView.nextLabel.text =
-        (index == steps.count - 1) ? R.string.global.actionDone() : R.string.global.actionNext()
-        return (views.bodyView, views.arrowView)
-    }
-
-    func coachMarksController(
-        _ coachMarksController: CoachMarksController, didEndShowingBySkipping skipped: Bool
-    ) {
-        completion?()
-    }
-
-    func coachMarksController(
-        _ coachMarksController: CoachMarksController,
-        willShow coachMark: CoachMark,
-        at index: Int
-    ) {
-        print("InstructionsDriver: willShow step \(index)")
-        guard let view = resolveView(for: steps[index].targetKey) else {
-            print("InstructionsDriver: View not found for key \(steps[index].targetKey)")
-            return
+        func numberOfCoachMarks(for coachMarksController: CoachMarksController) -> Int {
+            steps.count
         }
 
-        // Try to find a parent UIScrollView and scroll to the target view
-        var superview = view.superview
-        while let sView = superview {
-            if let scrollView = sView as? UIScrollView {
-                print("InstructionsDriver: Found scroll view for \(steps[index].targetKey)")
-                let frame = view.convert(view.bounds, to: scrollView)
-                // Add vertical padding to make sure it's not stick to edges
-                let paddedFrame = frame.insetBy(dx: 0, dy: -40)
-
-                // Use animated: false to ensure immediate update before coach mark is drawn
-                scrollView.scrollRectToVisible(paddedFrame, animated: false)
-                scrollView.layoutIfNeeded()
-                print("InstructionsDriver: Scrolled to \(paddedFrame)")
-                break
+        func coachMarksController(
+            _ coachMarksController: CoachMarksController, coachMarkAt index: Int
+        )
+            -> CoachMark
+        {
+            let key = steps[index].targetKey
+            logger.debug("coachMarkAt index=\(index), key=\(key)")
+            guard let host, let window = host.view.window else {
+                logger.error("coachMarkAt: host/window missing. key=\(key)")
+                return coachMarksController.helper.makeCoachMark()
             }
-            superview = sView.superview
-        }
-    }
 
-    private func resolveView(for key: String) -> UIView? {
-        // 1) Search in controller's root view hierarchy
-        if let container = host?.view,
-           let found = findView(withAccessibilityIdentifier: key, in: container)
-        {
-            return found
+            if let view = resolveView(for: key), view.window != nil {
+                return coachMarksController.helper.makeCoachMark(for: view)
+            }
+
+            let fallbackFrame = CGRect(
+                x: window.bounds.midX,
+                y: window.bounds.midY,
+                width: 1,
+                height: 1
+            )
+            return coachMarksController.helper.makeCoachMark(forFrame: fallbackFrame, in: window)
         }
-        // 2) Search in navigation controller's view (includes navigation bar)
-        if let navView = host?.navigationController?.view,
-           let found = findView(withAccessibilityIdentifier: key, in: navView)
-        {
-            return found
+
+        func coachMarksController(
+            _ coachMarksController: CoachMarksController,
+            coachMarkViewsAt index: Int,
+            madeFrom coachMark: CoachMark
+        ) -> (bodyView: UIView & CoachMarkBodyView, arrowView: (UIView & CoachMarkArrowView)?) {
+            logger.debug("coachMarkViewsAt index=\(index), key=\(steps[index].targetKey)")
+            let views = coachMarksController.helper.makeDefaultCoachViews(
+                withArrow: true, arrowOrientation: coachMark.arrowOrientation)
+            views.bodyView.hintLabel.text = steps[index].title + "\n" + steps[index].message
+            views.bodyView.nextLabel.text =
+                (index == steps.count - 1)
+                ? R.string.global.actionDone() : R.string.global.actionNext()
+            views.bodyView.isHidden = false
+            views.bodyView.alpha = 1
+            if let body = views.bodyView as? CoachMarkBodyDefaultView {
+                body.hintLabel.textColor = .white
+                body.nextLabel.textColor = .white
+                body.background.innerColor = UIColor.black.withAlphaComponent(0.85)
+                body.background.borderColor = UIColor.white.withAlphaComponent(0.12)
+            }
+            return (views.bodyView, views.arrowView)
         }
-        // 3) Directly check common bar button custom views
-        if key == "navBarAddOrder" || key == "navBarAddCost" || key == "navBarAddProduct" {
-            if let custom = host?.navigationItem.rightBarButtonItem?.customView,
-               custom.accessibilityIdentifier == key
+
+        func coachMarksController(
+            _ coachMarksController: CoachMarksController, didEndShowingBySkipping skipped: Bool
+        ) {
+            completion?()
+        }
+
+        func coachMarksController(
+            _ coachMarksController: CoachMarksController,
+            willLoadCoachMarkAt index: Int
+        ) -> Bool {
+            let key = self.steps[index].targetKey
+            logger.debug("willLoadCoachMarkAt index=\(index), key=\(key)")
+            guard let host = self.host, let window = host.view.window else { return true }
+            if let view = self.resolveView(for: key) {
+                self.scrollToReveal(view: view)
+                host.view.layoutIfNeeded()
+                window.layoutIfNeeded()
+            }
+            return true
+        }
+
+        func coachMarksController(
+            _ coachMarksController: CoachMarksController,
+            willShow coachMark: inout CoachMark,
+            beforeChanging change: ConfigurationChange,
+            at index: Int
+        ) {
+            let key = self.steps[index].targetKey
+            let cutout = coachMark.cutoutPath?.bounds.debugDescription ?? "nil"
+            logger.debug(
+                "willShow index=\(index), key=\(key), change=\(String(describing: change)), cutout=\(cutout)"
+            )
+            guard let host = self.host, let window = host.view.window else { return }
+            guard let cutoutBounds = coachMark.cutoutPath?.bounds else { return }
+
+            let safeBounds = window.bounds.inset(by: window.safeAreaInsets)
+            let spaceAbove = cutoutBounds.minY - safeBounds.minY
+            let spaceBelow = safeBounds.maxY - cutoutBounds.maxY
+            coachMark.arrowOrientation = (spaceBelow >= spaceAbove) ? .top : .bottom
+        }
+
+        private func updateToFallbackCenter(
+            in window: UIWindow, coachMarksController: CoachMarksController
+        ) {
+            coachMarksController.helper.updateCurrentCoachMark { coachMark, converter in
+                let frame = CGRect(
+                    x: window.bounds.midX, y: window.bounds.midY, width: 1, height: 1)
+                let converted = converter.convert(rect: frame, from: window)
+                coachMark.cutoutPath = UIBezierPath(
+                    roundedRect: converted.insetBy(dx: -4, dy: -4),
+                    byRoundingCorners: .allCorners,
+                    cornerRadii: CGSize(width: 4, height: 4)
+                )
+                coachMark.pointOfInterest = CGPoint(x: converted.midX, y: converted.midY)
+            }
+        }
+
+        private func scrollToReveal(view: UIView) {
+            let padding: CGFloat = 20
+            if let cell = superview(of: UITableViewCell.self, from: view),
+                let tableView = superview(of: UITableView.self, from: cell),
+                let indexPath = tableView.indexPath(for: cell)
             {
-                return custom
-            }
-        }
-        // 4) As a last resort, search the whole window
-        if let window = host?.view.window {
-            for sub in window.subviews {
-                if let found = findView(withAccessibilityIdentifier: key, in: sub) { return found }
-            }
-        }
-        return nil
-    }
+                let rectInTable = cell.convert(cell.bounds, to: tableView)
+                let visible = tableView.bounds.inset(by: UIEdgeInsets(
+                    top: padding, left: 0, bottom: padding, right: 0))
+                if visible.contains(rectInTable) {
+                    tableView.layoutIfNeeded()
+                    return
+                }
 
-    private func findView(withAccessibilityIdentifier id: String, in root: UIView) -> UIView? {
-        if root.accessibilityIdentifier == id { return root }
-        for sub in root.subviews {
-            if let found = findView(withAccessibilityIdentifier: id, in: sub) { return found }
+                tableView.scrollToRow(at: indexPath, at: .top, animated: false)
+                var offset = tableView.contentOffset
+                offset.y = max(-tableView.adjustedContentInset.top, offset.y - padding)
+                tableView.setContentOffset(offset, animated: false)
+                tableView.layoutIfNeeded()
+                return
+            }
+
+            if let cell = superview(of: UICollectionViewCell.self, from: view),
+                let collectionView = superview(of: UICollectionView.self, from: cell),
+                let indexPath = collectionView.indexPath(for: cell)
+            {
+                let rectInCollection = cell.convert(cell.bounds, to: collectionView)
+                let visible = collectionView.bounds.inset(by: UIEdgeInsets(
+                    top: padding, left: 0, bottom: padding, right: 0))
+                if visible.contains(rectInCollection) {
+                    collectionView.layoutIfNeeded()
+                    return
+                }
+
+                collectionView.scrollToItem(at: indexPath, at: .top, animated: false)
+                var offset = collectionView.contentOffset
+                offset.y = max(-collectionView.adjustedContentInset.top, offset.y - padding)
+                collectionView.setContentOffset(offset, animated: false)
+                collectionView.layoutIfNeeded()
+                return
+            }
+
+            if let scrollView = superview(of: UIScrollView.self, from: view) {
+                let rect = view.convert(view.bounds, to: scrollView)
+                let visible = scrollView.bounds.inset(by: UIEdgeInsets(
+                    top: padding, left: padding, bottom: padding, right: padding))
+                if visible.contains(rect) {
+                    scrollView.layoutIfNeeded()
+                    return
+                }
+
+                var targetOffset = scrollView.contentOffset
+                if rect.minY < visible.minY {
+                    targetOffset.y -= (visible.minY - rect.minY)
+                } else if rect.maxY > visible.maxY {
+                    targetOffset.y += (rect.maxY - visible.maxY)
+                }
+
+                let minY = -scrollView.adjustedContentInset.top
+                let maxY = max(
+                    minY,
+                    scrollView.contentSize.height - scrollView.bounds.height + scrollView.adjustedContentInset.bottom
+                )
+                targetOffset.y = min(max(targetOffset.y, minY), maxY)
+                scrollView.setContentOffset(targetOffset, animated: false)
+                scrollView.layoutIfNeeded()
+            }
         }
-        return nil
+
+        private func superview<T: UIView>(of type: T.Type, from view: UIView) -> T? {
+            var current: UIView? = view
+            while let currentView = current {
+                if let match = currentView as? T { return match }
+                current = currentView.superview
+            }
+            return nil
+        }
+
+        private func resolveView(for key: String) -> UIView? {
+            // 1) Search in controller's root view hierarchy
+            if let container = host?.view,
+                let found = findView(withAccessibilityIdentifier: key, in: container)
+            {
+                return found
+            }
+            // 2) Search in navigation controller's view (includes navigation bar)
+            if let navView = host?.navigationController?.view,
+                let found = findView(withAccessibilityIdentifier: key, in: navView)
+            {
+                return found
+            }
+            // 3) Directly check common bar button custom views
+            if key == "navBarAddOrder" || key == "navBarAddCost" || key == "navBarAddProduct" {
+                if let custom = host?.navigationItem.rightBarButtonItem?.customView,
+                    custom.accessibilityIdentifier == key
+                {
+                    return custom
+                }
+            }
+            // 4) As a last resort, search the whole window
+            if let window = host?.view.window {
+                for sub in window.subviews {
+                    if let found = findView(withAccessibilityIdentifier: key, in: sub) {
+                        return found
+                    }
+                }
+            }
+            return nil
+        }
+
+        private func findView(withAccessibilityIdentifier id: String, in root: UIView) -> UIView? {
+            if root.accessibilityIdentifier == id { return root }
+            for sub in root.subviews {
+                if let found = findView(withAccessibilityIdentifier: id, in: sub) { return found }
+            }
+            return nil
+        }
     }
-}
 #endif


### PR DESCRIPTION
## Title

- fix(onboarding): coach marks auto-scroll + order UI insets

## Plan

- Ensure coach mark targets are scrolled into view (with padding) only when needed.
- Keep onboarding “Next” button within safe area.
- Normalize order products list horizontal insets without double-padding.

## Code

- Updated coach marks driver to scroll target views into the visible area and avoid unnecessary scrolling.
- Adjusted onboarding next button constraints to respect safe area.
- Reworked order product list insets by relying on layout margins (table/host) instead of hardcoding padding in the cell.

## Expected outcome

- Coach marks should highlight the correct element even when it starts below the visible area.
- Onboarding “Next” button stays visible on devices with smaller screens / safe area.
- Order products list no longer shows unintended extra horizontal gaps.

## Validation

- Compiles in IDE; requires visual verification in iOS Simulator due to UI changes.

## References

- Related: onboarding coach marks + order UI polishing