### PR TITLE
feat(images): attach image to product and category

### DIFF
--- a/R.generated.swift
+++ b/R.generated.swift
@@ -225,7 +225,7 @@ struct _R {
       var useBioAuth: RswiftResources.StringResource1<String> { .init(key: "useBioAuth", tableName: "Auth", source: source, developmentValue: "Use %@ for quick authorization", comment: nil) }
     }
 
-    /// This `_R.string.global` struct is generated, and contains static references to 371 localization keys.
+    /// This `_R.string.global` struct is generated, and contains static references to 372 localization keys.
     struct global {
       let source: RswiftResources.StringResource.Source
 
@@ -942,6 +942,13 @@ struct _R {
       ///
       /// Locales: en, uk
       var failedSentTechnicianEmail: RswiftResources.StringResource { .init(key: "failedSentTechnicianEmail", tableName: "Global", source: source, developmentValue: "Something went wrong, please try again later\nYou can send invite email from technician details screen", comment: nil) }
+
+      /// en translation: Failed to save product category
+      ///
+      /// Key: failedToSaveProductCategory
+      ///
+      /// Locales: en, uk
+      var failedToSaveProductCategory: RswiftResources.StringResource { .init(key: "failedToSaveProductCategory", tableName: "Global", source: source, developmentValue: "Failed to save product category", comment: nil) }
 
       /// en translation: Failed to save product price
       ///

--- a/TrackMyCafe.xcodeproj/project.pbxproj
+++ b/TrackMyCafe.xcodeproj/project.pbxproj
@@ -650,6 +650,15 @@
 		F3F203762FD521B5007249FB /* OrderPickerProductTileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F203722FD521B5007249FB /* OrderPickerProductTileCell.swift */; };
 		F3F203772FD521B5007249FB /* OrderPickerCategoryGridCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F203712FD521B5007249FB /* OrderPickerCategoryGridCell.swift */; };
 		F3F203782FD521B5007249FB /* OrderPickerProductTileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F203722FD521B5007249FB /* OrderPickerProductTileCell.swift */; };
+		F3F2053E2FD83115007249FB /* ImageStoragePaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F2053D2FD83115007249FB /* ImageStoragePaths.swift */; };
+		F3F2053F2FD83115007249FB /* ImageStoragePaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F2053D2FD83115007249FB /* ImageStoragePaths.swift */; };
+		F3F205402FD83115007249FB /* ImageStoragePaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F2053D2FD83115007249FB /* ImageStoragePaths.swift */; };
+		F3F205422FD8313B007249FB /* ImageStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F205412FD8313B007249FB /* ImageStorageService.swift */; };
+		F3F205432FD8313B007249FB /* ImageStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F205412FD8313B007249FB /* ImageStorageService.swift */; };
+		F3F205442FD8313B007249FB /* ImageStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F205412FD8313B007249FB /* ImageStorageService.swift */; };
+		F3F205532FD831A0007249FB /* DomainProductCategoryDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F205522FD831A0007249FB /* DomainProductCategoryDataService.swift */; };
+		F3F205542FD831A0007249FB /* DomainProductCategoryDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F205522FD831A0007249FB /* DomainProductCategoryDataService.swift */; };
+		F3F205552FD831A0007249FB /* DomainProductCategoryDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F205522FD831A0007249FB /* DomainProductCategoryDataService.swift */; };
 		F3F6A6012C2FEB0A000961C8 /* SubscriptionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F6A6002C2FEB0A000961C8 /* SubscriptionType.swift */; };
 		F3F6A6022C2FEB0A000961C8 /* SubscriptionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F6A6002C2FEB0A000961C8 /* SubscriptionType.swift */; };
 		F3F6A6032C2FEB0A000961C8 /* SubscriptionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F6A6002C2FEB0A000961C8 /* SubscriptionType.swift */; };
@@ -941,6 +950,9 @@
 		F3F2036A2FD521A5007249FB /* OrderCategoryFirstProductsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCategoryFirstProductsViewController.swift; sourceTree = "<group>"; };
 		F3F203712FD521B5007249FB /* OrderPickerCategoryGridCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPickerCategoryGridCell.swift; sourceTree = "<group>"; };
 		F3F203722FD521B5007249FB /* OrderPickerProductTileCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPickerProductTileCell.swift; sourceTree = "<group>"; };
+		F3F2053D2FD83115007249FB /* ImageStoragePaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStoragePaths.swift; sourceTree = "<group>"; };
+		F3F205412FD8313B007249FB /* ImageStorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStorageService.swift; sourceTree = "<group>"; };
+		F3F205522FD831A0007249FB /* DomainProductCategoryDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainProductCategoryDataService.swift; sourceTree = "<group>"; };
 		F3F6A6002C2FEB0A000961C8 /* SubscriptionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionType.swift; sourceTree = "<group>"; };
 		F3F6A6042C2FEB9A000961C8 /* IAPManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPManager.swift; sourceTree = "<group>"; };
 		F3F6A6082C2FEBC0000961C8 /* IAPReceiptAdapterProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPReceiptAdapterProtocol.swift; sourceTree = "<group>"; };
@@ -960,6 +972,7 @@
 		F35E91AE2F49D7DA0050EB4A /* ProductCategories */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ProductCategories; sourceTree = "<group>"; };
 		F362781C2EE5508D00A69CFE /* Home */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Home; sourceTree = "<group>"; };
 		F3B7A8342EE220F0007BF216 /* Onboarding */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Onboarding; sourceTree = "<group>"; };
+		F3F205482FD8317B007249FB /* Utilities */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Utilities; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1477,6 +1490,7 @@
 		F3410E692BDD23BB0007157B /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				F3F2053D2FD83115007249FB /* ImageStoragePaths.swift */,
 				F3F6A5FE2C2FEAE0000961C8 /* Subscription */,
 				F3410E6A2BDD23E60007157B /* Constants.swift */,
 				F3410EA32BDD3C8E0007157B /* UserSession.swift */,
@@ -1951,6 +1965,7 @@
 		F39A52F327311FDD00C8F2D3 /* TrackMyCafe */ = {
 			isa = PBXGroup;
 			children = (
+				F3F205482FD8317B007249FB /* Utilities */,
 				F3B33AD42C0B28820073F19A /* Configuration */,
 				F38707DD2BE6207F00B6F313 /* Entitlements */,
 				F39A5331273250C300C8F2D3 /* Application */,
@@ -1997,6 +2012,7 @@
 		F39B5D2D28472E7A000F7D43 /* FIR */ = {
 			isa = PBXGroup;
 			children = (
+				F3F205412FD8313B007249FB /* ImageStorageService.swift */,
 				F39B5D2E28472EAE000F7D43 /* FirestoreDB.swift */,
 				F39B5D3028473465000F7D43 /* FirestoreDatabaseService.swift */,
 			);
@@ -2157,6 +2173,7 @@
 		F3E357E72BEFA203005050CB /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				F3F205522FD831A0007249FB /* DomainProductCategoryDataService.swift */,
 				F32B52B62F2B6F3D0005E63D /* DomainIngredientDataService.swift */,
 				F3D97EB72F4DF7D8006270AF /* DemoDataManager.swift */,
 				F36217CC2EC04E5300965886 /* DomainProductPriceDataService.swift */,
@@ -2275,6 +2292,7 @@
 				F35E91AE2F49D7DA0050EB4A /* ProductCategories */,
 				F362781C2EE5508D00A69CFE /* Home */,
 				F3B7A8342EE220F0007BF216 /* Onboarding */,
+				F3F205482FD8317B007249FB /* Utilities */,
 			);
 			name = "TrackMyCafe Prod";
 			packageProductDependencies = (
@@ -2323,6 +2341,7 @@
 				F35E91AE2F49D7DA0050EB4A /* ProductCategories */,
 				F362781C2EE5508D00A69CFE /* Home */,
 				F3B7A8342EE220F0007BF216 /* Onboarding */,
+				F3F205482FD8317B007249FB /* Utilities */,
 			);
 			name = "TrackMyCafe Beta";
 			packageProductDependencies = (
@@ -2371,6 +2390,7 @@
 				F35E91AE2F49D7DA0050EB4A /* ProductCategories */,
 				F362781C2EE5508D00A69CFE /* Home */,
 				F3B7A8342EE220F0007BF216 /* Onboarding */,
+				F3F205482FD8317B007249FB /* Utilities */,
 			);
 			name = "TrackMyCafe Dev";
 			packageProductDependencies = (
@@ -2872,6 +2892,7 @@
 				F3A640B82C340D21006BCACD /* SubscriptionReuseView.swift in Sources */,
 				F3410EB02BDD40410007157B /* Date+Extension.swift in Sources */,
 				F32B52B92F2B6F3D0005E63D /* DomainIngredientDataService.swift in Sources */,
+				F3F205432FD8313B007249FB /* ImageStorageService.swift in Sources */,
 				F3988ADE27EB11EB00215976 /* CostListItemViewModelType.swift in Sources */,
 				F39A53352732525900C8F2D3 /* OrderListViewController.swift in Sources */,
 				F36217CF2EC04E5300965886 /* DomainProductPriceDataService.swift in Sources */,
@@ -2918,11 +2939,13 @@
 				F3DD2197277AEF76001570D3 /* RealmProductsPriceModel.swift in Sources */,
 				F31BD82B284DF90200B8FD3B /* FIRProductsPriceModel.swift in Sources */,
 				F385B4152C1D863D00973CAA /* BaseReusableView.swift in Sources */,
+				F3F2053E2FD83115007249FB /* ImageStoragePaths.swift in Sources */,
 				F3821C8227EAEB97006D40FC /* OrderListItemViewModelType.swift in Sources */,
 				F385B40C2C1D7DDD00973CAA /* UIKitFactory.swift in Sources */,
 				F3A640BC2C341994006BCACD /* CreateEditTechnicianController.swift in Sources */,
 				F38EE5162C3939D500933E67 /* StaffCategoriesTableViewCell.swift in Sources */,
 				F316A2FB273808100083E830 /* UIFont+Extension.swift in Sources */,
+				F3F205532FD831A0007249FB /* DomainProductCategoryDataService.swift in Sources */,
 				F3821C5F27E9FC13006D40FC /* OrderListViewModel.swift in Sources */,
 				6E50D8DAB17C1B1436DACFE7 /* IngredientListViewController.swift in Sources */,
 				2A3DC05A20F5AAF1036F935B /* IngredientListViewModel.swift in Sources */,
@@ -3079,6 +3102,7 @@
 				F3A640B92C340D21006BCACD /* SubscriptionReuseView.swift in Sources */,
 				F3F6A6022C2FEB0A000961C8 /* SubscriptionType.swift in Sources */,
 				F32B52B82F2B6F3D0005E63D /* DomainIngredientDataService.swift in Sources */,
+				F3F205442FD8313B007249FB /* ImageStorageService.swift in Sources */,
 				F39D78532C2034DD0003B556 /* Technician.swift in Sources */,
 				F3B339EF2C0B22FE0073F19A /* RememberMeButton.swift in Sources */,
 				F36217CE2EC04E5300965886 /* DomainProductPriceDataService.swift in Sources */,
@@ -3125,11 +3149,13 @@
 				F3B33A062C0B22FE0073F19A /* SettingListViewController.swift in Sources */,
 				F3B33A072C0B22FE0073F19A /* RealmProductsPriceModel.swift in Sources */,
 				F3B33A082C0B22FE0073F19A /* FIRProductsPriceModel.swift in Sources */,
+				F3F2053F2FD83115007249FB /* ImageStoragePaths.swift in Sources */,
 				F3B33A092C0B22FE0073F19A /* OrderListItemViewModelType.swift in Sources */,
 				F3B33A0A2C0B22FE0073F19A /* UIFont+Extension.swift in Sources */,
 				F3A640BD2C341994006BCACD /* CreateEditTechnicianController.swift in Sources */,
 				F38EE5172C3939D500933E67 /* StaffCategoriesTableViewCell.swift in Sources */,
 				F3F6A6272C327A0B000961C8 /* PersonTableViewCell.swift in Sources */,
+				F3F205542FD831A0007249FB /* DomainProductCategoryDataService.swift in Sources */,
 				F3B33A0B2C0B22FE0073F19A /* OrderListViewModel.swift in Sources */,
 				6632D7C445B8F1727CFE69E2 /* IngredientListViewController.swift in Sources */,
 				97DFE5A38DEE5F1D153E1B5A /* IngredientListViewModel.swift in Sources */,
@@ -3286,6 +3312,7 @@
 				F3A640BA2C340D21006BCACD /* SubscriptionReuseView.swift in Sources */,
 				F3F6A6032C2FEB0A000961C8 /* SubscriptionType.swift in Sources */,
 				F32B52B72F2B6F3D0005E63D /* DomainIngredientDataService.swift in Sources */,
+				F3F205422FD8313B007249FB /* ImageStorageService.swift in Sources */,
 				F39D78542C2034DE0003B556 /* Technician.swift in Sources */,
 				F3B33A8E2C0B23450073F19A /* RememberMeButton.swift in Sources */,
 				F36217CD2EC04E5300965886 /* DomainProductPriceDataService.swift in Sources */,
@@ -3332,11 +3359,13 @@
 				F3B33AA52C0B23450073F19A /* SettingListViewController.swift in Sources */,
 				F3B33AA62C0B23450073F19A /* RealmProductsPriceModel.swift in Sources */,
 				F3B33AA72C0B23450073F19A /* FIRProductsPriceModel.swift in Sources */,
+				F3F205402FD83115007249FB /* ImageStoragePaths.swift in Sources */,
 				F3B33AA82C0B23450073F19A /* OrderListItemViewModelType.swift in Sources */,
 				F3B33AA92C0B23450073F19A /* UIFont+Extension.swift in Sources */,
 				F3A640BE2C341994006BCACD /* CreateEditTechnicianController.swift in Sources */,
 				F38EE5182C3939D500933E67 /* StaffCategoriesTableViewCell.swift in Sources */,
 				F3F6A6282C327A0B000961C8 /* PersonTableViewCell.swift in Sources */,
+				F3F205552FD831A0007249FB /* DomainProductCategoryDataService.swift in Sources */,
 				F3B33AAA2C0B23450073F19A /* OrderListViewModel.swift in Sources */,
 				0100A8D091003841AFDED1F1 /* IngredientListViewController.swift in Sources */,
 				DAB64B07CB231ED814B50F83 /* IngredientListViewModel.swift in Sources */,

--- a/TrackMyCafe/Data Layer/Models/Domain/ProductCategoryModel.swift
+++ b/TrackMyCafe/Data Layer/Models/Domain/ProductCategoryModel.swift
@@ -4,20 +4,24 @@ struct ProductCategoryModel: Identifiable, Codable {
     let id: String
     var name: String
     var sortOrder: Int
-    
+    var imagePath: String?
+
     init(
         id: String = UUID().uuidString,
         name: String,
-        sortOrder: Int = 0
+        sortOrder: Int = 0,
+        imagePath: String? = nil
     ) {
         self.id = id
         self.name = name
         self.sortOrder = sortOrder
+        self.imagePath = imagePath
     }
 
     init(firebaseModel: FIRProductCategoryModel) {
         self.id = firebaseModel.id ?? ""
         self.name = firebaseModel.name
         self.sortOrder = firebaseModel.sortOrder
+        self.imagePath = firebaseModel.imagePath
     }
 }

--- a/TrackMyCafe/Data Layer/Models/Domain/ProductsPriceModel.swift
+++ b/TrackMyCafe/Data Layer/Models/Domain/ProductsPriceModel.swift
@@ -13,19 +13,22 @@ struct ProductsPriceModel {
     var price: Double
     var categoryId: String?
     var recipe: [RecipeItemModel]
+    var imagePath: String?
     
     init(
         id: String,
         name: String,
         price: Double,
         categoryId: String? = nil,
-        recipe: [RecipeItemModel] = []
+        recipe: [RecipeItemModel] = [],
+        imagePath: String? = nil
     ) {
         self.id = id
         self.name = name
         self.price = price
         self.categoryId = categoryId
         self.recipe = recipe
+        self.imagePath = imagePath
     }
     
     init(realmModel: RealmProductsPriceModel) {
@@ -34,6 +37,7 @@ struct ProductsPriceModel {
         self.price = realmModel.price
         self.categoryId = nil
         self.recipe = realmModel.recipe.map { RecipeItemModel(realmModel: $0) }
+        self.imagePath = nil
     }
     
     init(firebaseModel: FIRProductsPriceModel) {
@@ -42,5 +46,6 @@ struct ProductsPriceModel {
         self.price = firebaseModel.price
         self.categoryId = firebaseModel.categoryId
         self.recipe = firebaseModel.recipe.map { RecipeItemModel(firebaseModel: $0) }
+        self.imagePath = firebaseModel.imagePath
     }
 }

--- a/TrackMyCafe/Data Layer/Models/Firestore/FIRProductCategoryModel.swift
+++ b/TrackMyCafe/Data Layer/Models/Firestore/FIRProductCategoryModel.swift
@@ -5,11 +5,12 @@ struct FIRProductCategoryModel: Codable {
     @DocumentID var id: String?
     var name: String = ""
     var sortOrder: Int = 0
+    var imagePath: String?
     
     init(dataModel: ProductCategoryModel) {
         self.id = dataModel.id
         self.name = dataModel.name
         self.sortOrder = dataModel.sortOrder
+        self.imagePath = dataModel.imagePath
     }
 }
-

--- a/TrackMyCafe/Data Layer/Models/Firestore/FIRProductsPriceModel.swift
+++ b/TrackMyCafe/Data Layer/Models/Firestore/FIRProductsPriceModel.swift
@@ -14,6 +14,7 @@ struct FIRProductsPriceModel: Codable {
   var price: Double = 0.0
   var categoryId: String?
   var recipe: [FIRRecipeItemModel] = []
+  var imagePath: String?
 
   init(dataModel: ProductsPriceModel) {
     self.id = dataModel.id
@@ -21,6 +22,7 @@ struct FIRProductsPriceModel: Codable {
     self.price = dataModel.price
     self.categoryId = dataModel.categoryId
     self.recipe = dataModel.recipe.map { FIRRecipeItemModel(dataModel: $0) }
+    self.imagePath = dataModel.imagePath
   }
 }
 

--- a/TrackMyCafe/Data Layer/Utils/ImageStoragePaths.swift
+++ b/TrackMyCafe/Data Layer/Utils/ImageStoragePaths.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum ImageStoragePaths {
+    static func productImagePath(productId: String) -> String {
+        "productImages/products/\(productId).jpg"
+    }
+
+    static func productCategoryImagePath(categoryId: String) -> String {
+        "productImages/categories/\(categoryId).jpg"
+    }
+}
+

--- a/TrackMyCafe/Extensions/UI/UIImageView+Extension.swift
+++ b/TrackMyCafe/Extensions/UI/UIImageView+Extension.swift
@@ -5,16 +5,116 @@
 //  Created by Леонід Квіт on 15.06.2024.
 //
 
+import ObjectiveC
 import UIKit
-//import Kingfisher
+
+private final class ImageLoadTaskBox: NSObject {
+    var task: Task<Void, Never>?
+}
+
+private enum UIImageViewAssociatedKeys {
+    static var imageLoadTaskBox = "UIImageView.imageLoadTaskBox"
+    static var imageLoadToken = "UIImageView.imageLoadToken"
+}
+
+enum AppImagePlaceholder {
+    static func product() -> UIImage? {
+        make(
+            systemName: "cup.and.saucer.fill",
+            pointSize: 26
+        )
+    }
+
+    static func category() -> UIImage? {
+        make(
+            systemName: "square.grid.2x2",
+            pointSize: 24
+        )
+    }
+
+    static func photo() -> UIImage? {
+        make(
+            systemName: "photo",
+            pointSize: 28
+        )
+    }
+
+    private static func make(systemName: String, pointSize: CGFloat) -> UIImage? {
+        let configuration = UIImage.SymbolConfiguration(pointSize: pointSize, weight: .medium)
+        return UIImage(systemName: systemName, withConfiguration: configuration)?
+            .withTintColor(
+                UIColor.TabBar.tint.withAlphaComponent(0.62),
+                renderingMode: .alwaysOriginal
+            )
+    }
+}
 
 extension UIImageView {
-    
-    func setImage(_ URL: URL?, placeholder: UIImage?) {
-        guard let imageURL = URL else {
-            self.image = placeholder
+    func cancelImageLoad() {
+        (objc_getAssociatedObject(self, &UIImageViewAssociatedKeys.imageLoadTaskBox)
+            as? ImageLoadTaskBox)?
+            .task?
+            .cancel()
+        objc_setAssociatedObject(
+            self,
+            &UIImageViewAssociatedKeys.imageLoadTaskBox,
+            nil,
+            .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        )
+    }
+
+    func setImage(pathOrURL: String?, placeholder: UIImage?) {
+        cancelImageLoad()
+
+        guard let pathOrURL, !pathOrURL.isEmpty else {
+            image = placeholder
             return
         }
-        setImage(imageURL, placeholder: placeholder)
+
+        image = placeholder
+
+        let token = UUID().uuidString
+        objc_setAssociatedObject(
+            self,
+            &UIImageViewAssociatedKeys.imageLoadToken,
+            token,
+            .OBJC_ASSOCIATION_COPY_NONATOMIC
+        )
+
+        let box = ImageLoadTaskBox()
+        box.task = Task { [weak self] in
+            do {
+                let img = try await ImageLoader.shared.loadImage(forPathOrURL: pathOrURL)
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    guard let self else { return }
+                    let currentToken =
+                        objc_getAssociatedObject(self, &UIImageViewAssociatedKeys.imageLoadToken)
+                        as? String
+                    guard currentToken == token else { return }
+                    self.image = img
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+            }
+        }
+        objc_setAssociatedObject(
+            self,
+            &UIImageViewAssociatedKeys.imageLoadTaskBox,
+            box,
+            .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        )
+    }
+
+    func setImage(_ url: URL?, placeholder: UIImage?) {
+        guard let url else {
+            setImage(pathOrURL: nil, placeholder: placeholder)
+            return
+        }
+        setImage(url, placeholder: placeholder)
+    }
+
+    func setImage(_ url: URL, placeholder: UIImage?) {
+        setImage(pathOrURL: url.absoluteString, placeholder: placeholder)
     }
 }

--- a/TrackMyCafe/Resources/Localization/en.lproj/Global.strings
+++ b/TrackMyCafe/Resources/Localization/en.lproj/Global.strings
@@ -369,6 +369,7 @@
 "enterQuantityPerUnit" = "Enter quantity per unit";
 "pleaseEnterProductName" = "Please enter product name";
 "failedToSaveProductPrice" = "Failed to save product price";
+"failedToSaveProductCategory" = "Failed to save product category";
 
 "ingredientAlreadyExists" = "Ingredient already exists";
 "overwriteIngredientMessage" = "This ingredient is already in the recipe. Do you want to overwrite it?";

--- a/TrackMyCafe/Resources/Localization/uk.lproj/Global.strings
+++ b/TrackMyCafe/Resources/Localization/uk.lproj/Global.strings
@@ -369,6 +369,7 @@
 "enterQuantityPerUnit" = "Введіть кількість на одиницю";
 "pleaseEnterProductName" = "Будь ласка, введіть назву товару";
 "failedToSaveProductPrice" = "Не вдалося зберегти ціну товару";
+"failedToSaveProductCategory" = "Не вдалося зберегти категорію товарів";
 
 "ingredientAlreadyExists" = "Інгредієнт вже існує";
 "overwriteIngredientMessage" = "Цей інгредієнт вже є в рецепті. Ви хочете перезаписати його?";

--- a/TrackMyCafe/Services/Domain/DomainProductCategoryDataService.swift
+++ b/TrackMyCafe/Services/Domain/DomainProductCategoryDataService.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+enum DomainProductCategoryError: Error {
+    case saveFailed
+}
+
+protocol ProductCategoryDataServiceProtocol {
+    func saveCategory(_ category: ProductCategoryModel) async throws
+}
+
+final class DomainProductCategoryDataService: ProductCategoryDataServiceProtocol {
+    @MainActor
+    func saveCategory(_ category: ProductCategoryModel) async throws {
+        let firModel = FIRProductCategoryModel(dataModel: category)
+
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
+            FirestoreDatabaseService.shared.update(
+                firModel: firModel,
+                collection: FirebaseCollections.productCategories,
+                documentId: category.id
+            ) { result in
+                switch result {
+                case .success:
+                    continuation.resume(returning: ())
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/TrackMyCafe/Services/Domain/DomainProductPriceDataService.swift
+++ b/TrackMyCafe/Services/Domain/DomainProductPriceDataService.swift
@@ -8,30 +8,47 @@
 import Foundation
 
 enum DomainProductPriceError: Error {
-  case saveFailed
+    case saveFailed
 }
 
 protocol ProductPriceDataServiceProtocol {
-  func saveProductPrice(_ productPrice: ProductsPriceModel) async throws
-  func updateProductPrice(_ productPrice: ProductsPriceModel, name: String, price: Double) async
+    func saveProductPrice(_ productPrice: ProductsPriceModel) async throws
+    func updateProductPrice(_ productPrice: ProductsPriceModel, name: String, price: Double) async throws
 }
 
 final class DomainProductPriceDataService: ProductPriceDataServiceProtocol {
-  @MainActor
-  func saveProductPrice(_ productPrice: ProductsPriceModel) async throws {
-    try await withCheckedThrowingContinuation { continuation in
-      DomainDatabaseService.shared.saveProductsPrice(productPrice: productPrice) { success in
-        if success {
-          continuation.resume()
-        } else {
-          continuation.resume(throwing: DomainProductPriceError.saveFailed)
+    @MainActor
+    func saveProductPrice(_ productPrice: ProductsPriceModel) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            DomainDatabaseService.shared.saveProductsPrice(productPrice: productPrice) { success in
+                if success {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: DomainProductPriceError.saveFailed)
+                }
+            }
         }
-      }
     }
-  }
-
-  @MainActor
-  func updateProductPrice(_ productPrice: ProductsPriceModel, name: String, price: Double) async {
-    DomainDatabaseService.shared.updateProductsPrice(model: productPrice, name: name, price: price)
-  }
+    
+    @MainActor
+    func updateProductPrice(_ productPrice: ProductsPriceModel, name: String, price: Double) async throws {
+        var updatedModel = FIRProductsPriceModel(dataModel: productPrice)
+        updatedModel.name = name
+        updatedModel.price = price
+        
+        try await withCheckedThrowingContinuation { continuation in
+            FirestoreDatabaseService.shared.update(
+                firModel: updatedModel,
+                collection: FirebaseCollections.productsPrice,
+                documentId: productPrice.id
+            ) { result in
+                switch result {
+                case .success:
+                    continuation.resume()
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
 }

--- a/TrackMyCafe/Services/FIR/ImageStorageService.swift
+++ b/TrackMyCafe/Services/FIR/ImageStorageService.swift
@@ -1,0 +1,82 @@
+import FirebaseStorage
+import Foundation
+
+protocol ImageStorageServiceProtocol {
+    func upload(data: Data, toPath path: String, contentType: String) async throws
+    func delete(atPath path: String) async throws
+    func downloadData(atPath path: String, maxSize: Int64) async throws -> Data
+}
+
+final class FirebaseImageStorageService: ImageStorageServiceProtocol {
+    static let shared = FirebaseImageStorageService()
+
+    private func makeReference(path: String) -> StorageReference {
+        var ref = Storage.storage().reference()
+        for part in path.split(separator: "/").map(String.init) where !part.isEmpty {
+            ref = ref.child(part)
+        }
+        return ref
+    }
+
+    func upload(data: Data, toPath path: String, contentType: String) async throws {
+        let metadata = StorageMetadata()
+        metadata.contentType = contentType
+
+        try await putData(ref: makeReference(path: path), data: data, metadata: metadata)
+    }
+
+    func delete(atPath path: String) async throws {
+        let ref = makeReference(path: path)
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
+            ref.delete { error in
+                if let error, self.isObjectNotFound(error) {
+                    continuation.resume(returning: ())
+                    return
+                }
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: ())
+            }
+        }
+    }
+
+    func downloadData(atPath path: String, maxSize: Int64) async throws -> Data {
+        return try await getData(ref: makeReference(path: path), maxSize: maxSize)
+    }
+
+    private func putData(ref: StorageReference, data: Data, metadata: StorageMetadata) async throws
+    {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
+            ref.putData(data, metadata: metadata) { _, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: ())
+            }
+        }
+    }
+
+    private func getData(ref: StorageReference, maxSize: Int64) async throws -> Data {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Data, Error>) in
+            ref.getData(maxSize: maxSize) { data, error in
+                if let data {
+                    continuation.resume(returning: data)
+                    return
+                }
+                continuation.resume(throwing: error ?? URLError(.badServerResponse))
+            }
+        }
+    }
+
+    private func isObjectNotFound(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        guard nsError.domain == StorageErrorDomain else { return false }
+        return StorageErrorCode(rawValue: nsError.code) == .objectNotFound
+    }
+}

--- a/TrackMyCafe/Utilities/ImageDataCache.swift
+++ b/TrackMyCafe/Utilities/ImageDataCache.swift
@@ -1,0 +1,56 @@
+import CryptoKit
+import Foundation
+
+actor ImageDataCache {
+    static let shared = ImageDataCache()
+
+    private let memoryCache = NSCache<NSString, NSData>()
+    private let fileManager = FileManager.default
+    private let directoryURL: URL?
+
+    init() {
+        self.memoryCache.countLimit = 256
+        self.memoryCache.totalCostLimit = 64 * 1024 * 1024
+
+        guard let caches = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            self.directoryURL = nil
+            return
+        }
+        self.directoryURL = caches.appendingPathComponent("ImageDataCache", isDirectory: true)
+    }
+
+    func data(forKey key: String) -> Data? {
+        if let cached = memoryCache.object(forKey: key as NSString) {
+            return Data(referencing: cached)
+        }
+        guard let fileURL = diskURL(forKey: key) else { return nil }
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        memoryCache.setObject(data as NSData, forKey: key as NSString, cost: data.count)
+        return data
+    }
+
+    func store(_ data: Data, forKey key: String) {
+        memoryCache.setObject(data as NSData, forKey: key as NSString, cost: data.count)
+        guard let dir = directoryURL else { return }
+
+        if !fileManager.fileExists(atPath: dir.path) {
+            _ = try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        guard let fileURL = diskURL(forKey: key) else { return }
+        try? data.write(to: fileURL, options: [.atomic])
+    }
+
+    func remove(forKey key: String) {
+        memoryCache.removeObject(forKey: key as NSString)
+        guard let fileURL = diskURL(forKey: key) else { return }
+        try? fileManager.removeItem(at: fileURL)
+    }
+
+    private func diskURL(forKey key: String) -> URL? {
+        guard let dir = directoryURL else { return nil }
+        let digest = SHA256.hash(data: Data(key.utf8))
+        let fileName = digest.map { String(format: "%02x", $0) }.joined()
+        return dir.appendingPathComponent(fileName).appendingPathExtension("bin")
+    }
+}
+

--- a/TrackMyCafe/Utilities/ImageLoader.swift
+++ b/TrackMyCafe/Utilities/ImageLoader.swift
@@ -1,0 +1,42 @@
+import Foundation
+import UIKit
+
+final class ImageLoader {
+    static let shared = ImageLoader()
+
+    private let cache: ImageDataCache
+    private let storageService: ImageStorageServiceProtocol
+    private let urlSession: URLSession
+
+    init(
+        cache: ImageDataCache = .shared,
+        storageService: ImageStorageServiceProtocol = FirebaseImageStorageService.shared,
+        urlSession: URLSession = .shared
+    ) {
+        self.cache = cache
+        self.storageService = storageService
+        self.urlSession = urlSession
+    }
+
+    func loadImage(forPathOrURL pathOrURL: String) async throws -> UIImage {
+        if let cached = await cache.data(forKey: pathOrURL), let image = UIImage(data: cached) {
+            return image
+        }
+
+        let data: Data
+        if let url = URL(string: pathOrURL), url.scheme == "http" || url.scheme == "https" {
+            let (downloaded, _) = try await urlSession.data(from: url)
+            data = downloaded
+        } else {
+            data = try await storageService.downloadData(atPath: pathOrURL, maxSize: 15 * 1024 * 1024)
+        }
+
+        await cache.store(data, forKey: pathOrURL)
+        guard let image = UIImage(data: data) else {
+            await cache.remove(forKey: pathOrURL)
+            throw URLError(.cannotDecodeContentData)
+        }
+        return image
+    }
+}
+

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/Cells/OrderPickerCategoryGridCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/Cells/OrderPickerCategoryGridCell.swift
@@ -3,8 +3,20 @@ import UIKit
 
 final class OrderPickerCategoryGridCell: UICollectionViewCell {
     static let reuseIdentifier = "OrderPickerCategoryGridCell"
+    private enum Layout {
+        static let imageAspectRatio: CGFloat = 2.0 / 3.0
+    }
 
-    private let iconView: UIView = {
+    private lazy var contentStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [imageContainer, titleLabel])
+        stack.axis = .vertical
+        stack.alignment = .fill
+        stack.distribution = .fill
+        stack.spacing = 10
+        return stack
+    }()
+
+    private let imageContainer: UIView = {
         let view = UIView()
         view.backgroundColor = UIColor.TabBar.tint.alpha(0.14)
         view.layer.cornerRadius = 12
@@ -12,11 +24,18 @@ final class OrderPickerCategoryGridCell: UICollectionViewCell {
         return view
     }()
 
-    private let iconImageView: UIImageView = {
+    private let photoImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        return imageView
+    }()
+
+    private let placeholderImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
         imageView.tintColor = UIColor.TabBar.tint
-        imageView.image = UIImage(systemName: "square.grid.2x2")
+        imageView.image = AppImagePlaceholder.category()
         return imageView
     }()
 
@@ -37,21 +56,17 @@ final class OrderPickerCategoryGridCell: UICollectionViewCell {
         contentView.layer.cornerRadius = 14
         contentView.layer.masksToBounds = true
 
-        contentView.addSubview(iconView)
-        iconView.addSubview(iconImageView)
-        contentView.addSubview(titleLabel)
+        imageContainer.addSubview(photoImageView)
+        imageContainer.addSubview(placeholderImageView)
+        contentView.addSubview(contentStackView)
 
-        iconView.topToSuperview(offset: 12)
-        iconView.centerXToSuperview()
-        iconView.size(CGSize(width: 56, height: 56))
+        contentStackView.edgesToSuperview(insets: .uniform(12))
+        imageContainer.heightToWidth(of: imageContainer, multiplier: Layout.imageAspectRatio)
 
-        iconImageView.centerInSuperview()
-        iconImageView.size(CGSize(width: 26, height: 26))
+        photoImageView.edgesToSuperview()
 
-        titleLabel.topToBottom(of: iconView, offset: 10)
-        titleLabel.leftToSuperview(offset: 10)
-        titleLabel.rightToSuperview(offset: -10)
-        titleLabel.bottomToSuperview(offset: -10, relation: .equalOrLess)
+        placeholderImageView.centerInSuperview()
+        placeholderImageView.size(CGSize(width: 26, height: 26))
     }
 
     required init?(coder: NSCoder) {
@@ -64,9 +79,29 @@ final class OrderPickerCategoryGridCell: UICollectionViewCell {
         }
     }
 
-    func configure(title: String) {
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        photoImageView.cancelImageLoad()
+        photoImageView.image = nil
+        placeholderImageView.isHidden = false
+        titleLabel.text = nil
+        accessibilityLabel = nil
+    }
+
+    func configure(title: String, imagePath: String?) {
         titleLabel.text = title
         accessibilityLabel = title
         accessibilityTraits = [.button]
+
+        if let imagePath, !imagePath.isEmpty {
+            imageContainer.backgroundColor = UIColor.TabBar.tint.alpha(0.14)
+            photoImageView.setImage(
+                pathOrURL: imagePath, placeholder: AppImagePlaceholder.category())
+            placeholderImageView.isHidden = true
+        } else {
+            imageContainer.backgroundColor = UIColor.TabBar.tint.alpha(0.14)
+            photoImageView.image = nil
+            placeholderImageView.isHidden = false
+        }
     }
 }

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/Cells/OrderPickerProductTileCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/Cells/OrderPickerProductTileCell.swift
@@ -3,6 +3,9 @@ import UIKit
 
 final class OrderPickerProductTileCell: UICollectionViewCell {
     static let reuseIdentifier = "OrderPickerProductTileCell"
+    private enum Layout {
+        static let imageAspectRatio: CGFloat = 2.0 / 3.0
+    }
 
     var onMinusTapped: (() -> Void)?
 
@@ -14,11 +17,18 @@ final class OrderPickerProductTileCell: UICollectionViewCell {
         return view
     }()
 
+    private let photoImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        return imageView
+    }()
+
     private let imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
         imageView.tintColor = UIColor.TabBar.tint
-        imageView.image = UIImage(systemName: "cup.and.saucer.fill")
+        imageView.image = AppImagePlaceholder.product()
         return imageView
     }()
 
@@ -64,6 +74,15 @@ final class OrderPickerProductTileCell: UICollectionViewCell {
         return label
     }()
 
+    private lazy var textStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [titleLabel, priceLabel])
+        stack.axis = .vertical
+        stack.alignment = .fill
+        stack.distribution = .fill
+        stack.spacing = 4
+        return stack
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -73,16 +92,18 @@ final class OrderPickerProductTileCell: UICollectionViewCell {
         contentView.layer.masksToBounds = true
 
         contentView.addSubview(imageContainer)
+        imageContainer.addSubview(photoImageView)
         imageContainer.addSubview(imageView)
         imageContainer.addSubview(quantityLabel)
         contentView.addSubview(minusButton)
-        contentView.addSubview(titleLabel)
-        contentView.addSubview(priceLabel)
+        contentView.addSubview(textStackView)
 
         imageContainer.topToSuperview(offset: 12)
         imageContainer.leftToSuperview(offset: 12)
         imageContainer.rightToSuperview(offset: -12)
-        imageContainer.height(64)
+        imageContainer.heightToWidth(of: imageContainer, multiplier: Layout.imageAspectRatio)
+
+        photoImageView.edgesToSuperview()
 
         imageView.centerInSuperview()
         imageView.size(CGSize(width: 28, height: 28))
@@ -95,14 +116,10 @@ final class OrderPickerProductTileCell: UICollectionViewCell {
         minusButton.centerYToSuperview()
         minusButton.rightToSuperview(offset: -10)
 
-        titleLabel.topToBottom(of: imageContainer, offset: 10)
-        titleLabel.leftToSuperview(offset: 12)
-        titleLabel.rightToSuperview(offset: -12)
-
-        priceLabel.topToBottom(of: titleLabel, offset: 4)
-        priceLabel.leftToSuperview(offset: 12)
-        priceLabel.rightToSuperview(offset: -12)
-        priceLabel.bottomToSuperview(offset: -12, relation: .equalOrLess)
+        textStackView.topToBottom(of: imageContainer, offset: 10)
+        textStackView.leftToSuperview(offset: 12)
+        textStackView.rightToSuperview(offset: -(12 + 32 + 10))
+        textStackView.bottomToSuperview(offset: -12)
 
         minusButton.addTarget(self, action: #selector(minusTapped), for: .touchUpInside)
     }
@@ -114,6 +131,9 @@ final class OrderPickerProductTileCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         onMinusTapped = nil
+        photoImageView.cancelImageLoad()
+        photoImageView.image = nil
+        photoImageView.alpha = 1
         quantityLabel.isHidden = true
         minusButton.isHidden = true
         quantityLabel.text = nil
@@ -130,18 +150,34 @@ final class OrderPickerProductTileCell: UICollectionViewCell {
         }
     }
 
-    func configure(title: String, price: String, quantity: Int) {
+    func configure(title: String, price: String, quantity: Int, imagePath: String?) {
         titleLabel.text = title
         priceLabel.text = price
+
+        if let imagePath, !imagePath.isEmpty {
+            imageContainer.backgroundColor = UIColor.TabBar.tint.alpha(0.12)
+            photoImageView.setImage(
+                pathOrURL: imagePath, placeholder: AppImagePlaceholder.product())
+            imageView.isHidden = true
+        } else {
+            imageContainer.backgroundColor = UIColor.TabBar.tint.alpha(0.12)
+            photoImageView.image = nil
+            imageView.isHidden = false
+        }
 
         let isActive = quantity > 0
         quantityLabel.isHidden = !isActive
         minusButton.isHidden = !isActive
         if isActive {
             quantityLabel.text = "\(quantity)"
-            imageView.alpha = 0.18
-            imageView.tintColor = UIColor.Main.text.withAlphaComponent(0.25)
+            if imageView.isHidden {
+                photoImageView.alpha = 0.35
+            } else {
+                imageView.alpha = 0.18
+                imageView.tintColor = UIColor.Main.text.withAlphaComponent(0.25)
+            }
         } else {
+            photoImageView.alpha = 1
             imageView.alpha = 1
             imageView.tintColor = UIColor.TabBar.tint
         }

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/Cells/ProductGridCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/Cells/ProductGridCell.swift
@@ -3,6 +3,32 @@ import UIKit
 
 final class ProductGridCell: UICollectionViewCell {
     static let reuseIdentifier = "ProductGridCell"
+    private enum Layout {
+        static let imageAspectRatio: CGFloat = 2.0 / 3.0
+    }
+
+    private let imageContainer: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.TabBar.tint.alpha(0.12)
+        view.layer.cornerRadius = 10
+        view.layer.masksToBounds = true
+        return view
+    }()
+
+    private let photoImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        return imageView
+    }()
+
+    private let placeholderImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.tintColor = UIColor.TabBar.tint
+        imageView.image = AppImagePlaceholder.product()
+        return imageView
+    }()
 
     private let titleLabel: UILabel = {
         let label = UILabel()
@@ -26,23 +52,53 @@ final class ProductGridCell: UICollectionViewCell {
         contentView.layer.masksToBounds = true
         isAccessibilityElement = true
 
-        let stack = UIStackView(arrangedSubviews: [titleLabel, priceLabel])
+        imageContainer.addSubview(photoImageView)
+        imageContainer.addSubview(placeholderImageView)
+
+        photoImageView.edgesToSuperview()
+        placeholderImageView.centerInSuperview()
+        placeholderImageView.size(CGSize(width: 22, height: 22))
+
+        let stack = UIStackView(arrangedSubviews: [imageContainer, titleLabel, priceLabel])
         stack.axis = .vertical
         stack.alignment = .fill
         stack.distribution = .fill
         stack.spacing = 6
         contentView.addSubview(stack)
         stack.edgesToSuperview(insets: .uniform(12))
+
+        imageContainer.heightToWidth(of: imageContainer, multiplier: Layout.imageAspectRatio)
     }
 
     required init?(coder: NSCoder) {
         return nil
     }
 
-    func configure(title: String, price: String) {
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        photoImageView.cancelImageLoad()
+        photoImageView.image = nil
+        placeholderImageView.isHidden = false
+        titleLabel.text = nil
+        priceLabel.text = nil
+        accessibilityLabel = nil
+    }
+
+    func configure(title: String, price: String, imagePath: String?) {
         titleLabel.text = title
         priceLabel.text = price
         accessibilityLabel = "\(title), \(price)"
         accessibilityHint = R.string.global.add()
+
+        if let imagePath, !imagePath.isEmpty {
+            imageContainer.backgroundColor = UIColor.TabBar.tint.alpha(0.12)
+            photoImageView.setImage(
+                pathOrURL: imagePath, placeholder: AppImagePlaceholder.product())
+            placeholderImageView.isHidden = true
+        } else {
+            imageContainer.backgroundColor = UIColor.TabBar.tint.alpha(0.12)
+            photoImageView.image = nil
+            placeholderImageView.isHidden = false
+        }
     }
 }

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderCategoryFirstPickerViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderCategoryFirstPickerViewController.swift
@@ -15,7 +15,8 @@ final class OrderCategoryFirstPickerViewController: UIViewController {
     private var collectionBottomConstraint: Constraint?
 
     private let collectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+        let collectionView = UICollectionView(
+            frame: .zero, collectionViewLayout: UICollectionViewLayout())
         collectionView.backgroundColor = UIColor.Main.background
         collectionView.alwaysBounceVertical = true
         return collectionView
@@ -95,7 +96,8 @@ final class OrderCategoryFirstPickerViewController: UIViewController {
                 comment: ""
             )
         } else {
-            navigationItem.backButtonTitle = NSLocalizedString("back", tableName: "Global", comment: "")
+            navigationItem.backButtonTitle = NSLocalizedString(
+                "back", tableName: "Global", comment: "")
         }
 
         if navigationController?.presentingViewController != nil {
@@ -153,7 +155,8 @@ final class OrderCategoryFirstPickerViewController: UIViewController {
 
         returnToOrderButton.leftToSuperview(offset: UIConstants.standardPadding)
         returnToOrderButton.rightToSuperview(offset: -UIConstants.standardPadding)
-        returnToOrderButton.bottomToSuperview(offset: -UIConstants.standardPadding, usingSafeArea: true)
+        returnToOrderButton.bottomToSuperview(
+            offset: -UIConstants.standardPadding, usingSafeArea: true)
         returnToOrderButton.height(UIConstants.buttonHeight)
         returnToOrderButton.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
     }
@@ -217,13 +220,13 @@ final class OrderCategoryFirstPickerViewController: UIViewController {
 
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .fractionalHeight(1.0)
+                heightDimension: .estimated(160)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(132)
+                heightDimension: .estimated(160)
             )
             let group = NSCollectionLayoutGroup.horizontal(
                 layoutSize: groupSize,
@@ -255,8 +258,12 @@ final class OrderCategoryFirstPickerViewController: UIViewController {
     }
 }
 
-extension OrderCategoryFirstPickerViewController: UICollectionViewDataSource, UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+extension OrderCategoryFirstPickerViewController: UICollectionViewDataSource,
+    UICollectionViewDelegate
+{
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int)
+        -> Int
+    {
         categories.count
     }
 
@@ -272,7 +279,7 @@ extension OrderCategoryFirstPickerViewController: UICollectionViewDataSource, UI
         else { return UICollectionViewCell() }
 
         let category = categories[indexPath.item]
-        cell.configure(title: category.name)
+        cell.configure(title: category.name, imagePath: category.imagePath)
         return cell
     }
 

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderCategoryFirstProductsViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderCategoryFirstProductsViewController.swift
@@ -20,7 +20,8 @@ final class OrderCategoryFirstProductsViewController: UIViewController {
     private var collectionBottomConstraint: Constraint?
 
     private let collectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+        let collectionView = UICollectionView(
+            frame: .zero, collectionViewLayout: UICollectionViewLayout())
         collectionView.backgroundColor = UIColor.Main.background
         collectionView.alwaysBounceVertical = true
         return collectionView
@@ -163,7 +164,8 @@ final class OrderCategoryFirstProductsViewController: UIViewController {
 
         returnToOrderButton.leftToSuperview(offset: UIConstants.standardPadding)
         returnToOrderButton.rightToSuperview(offset: -UIConstants.standardPadding)
-        returnToOrderButton.bottomToSuperview(offset: -UIConstants.standardPadding, usingSafeArea: true)
+        returnToOrderButton.bottomToSuperview(
+            offset: -UIConstants.standardPadding, usingSafeArea: true)
         returnToOrderButton.height(UIConstants.buttonHeight)
         returnToOrderButton.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
     }
@@ -224,13 +226,13 @@ final class OrderCategoryFirstProductsViewController: UIViewController {
 
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .fractionalHeight(1.0)
+                heightDimension: .estimated(220)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(168)
+                heightDimension: .estimated(220)
             )
             let group = NSCollectionLayoutGroup.horizontal(
                 layoutSize: groupSize,
@@ -269,8 +271,12 @@ final class OrderCategoryFirstProductsViewController: UIViewController {
     }
 }
 
-extension OrderCategoryFirstProductsViewController: UICollectionViewDataSource, UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+extension OrderCategoryFirstProductsViewController: UICollectionViewDataSource,
+    UICollectionViewDelegate
+{
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int)
+        -> Int
+    {
         filteredProducts.count
     }
 
@@ -291,7 +297,8 @@ extension OrderCategoryFirstProductsViewController: UICollectionViewDataSource, 
         cell.configure(
             title: product.name,
             price: product.price.currency,
-            quantity: qty
+            quantity: qty,
+            imagePath: product.imagePath
         )
 
         cell.onMinusTapped = { [weak self] in

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderProductPickerViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderProductPickerViewController.swift
@@ -24,7 +24,8 @@ final class OrderProductPickerViewController: UIViewController, Loggable {
 
     private var displayedCategories: [ProductCategoryModel] {
         let allTitle = NSLocalizedString("all", tableName: "Global", comment: "")
-        let allCategory = ProductCategoryModel(id: CategoryConstants.allId, name: allTitle, sortOrder: -1)
+        let allCategory = ProductCategoryModel(
+            id: CategoryConstants.allId, name: allTitle, sortOrder: -1)
         return [allCategory] + categories
     }
 
@@ -48,7 +49,8 @@ final class OrderProductPickerViewController: UIViewController, Loggable {
     }()
 
     private lazy var productsCollectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeProductsLayout())
+        let collectionView = UICollectionView(
+            frame: .zero, collectionViewLayout: makeProductsLayout())
         collectionView.backgroundColor = UIColor.Main.background
         collectionView.alwaysBounceVertical = true
         return collectionView
@@ -191,15 +193,16 @@ final class OrderProductPickerViewController: UIViewController, Loggable {
 
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .fractionalHeight(1.0)
+                heightDimension: .estimated(160)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(84)
+                heightDimension: .estimated(160)
             )
-            let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: columns)
+            let group = NSCollectionLayoutGroup.horizontal(
+                layoutSize: groupSize, subitem: item, count: columns)
             group.interItemSpacing = .fixed(spacing)
 
             let section = NSCollectionLayoutSection(group: group)
@@ -216,8 +219,11 @@ final class OrderProductPickerViewController: UIViewController, Loggable {
 }
 
 extension OrderProductPickerViewController: UICollectionViewDelegate, UICollectionViewDataSource,
-    UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    UICollectionViewDelegateFlowLayout
+{
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int)
+        -> Int
+    {
         if collectionView === categoriesCollectionView {
             return displayedCategories.count
         }
@@ -240,7 +246,8 @@ extension OrderProductPickerViewController: UICollectionViewDelegate, UICollecti
             else { return UICollectionViewCell() }
 
             let category = displayedCategories[indexPath.item]
-            let isSelected = (category.id == CategoryConstants.allId)
+            let isSelected =
+                (category.id == CategoryConstants.allId)
                 ? (selectedCategoryId == nil)
                 : (category.id == selectedCategoryId)
             cell.configure(title: category.name, isSelected: isSelected)
@@ -255,7 +262,8 @@ extension OrderProductPickerViewController: UICollectionViewDelegate, UICollecti
         else { return UICollectionViewCell() }
 
         let product = filteredProducts[indexPath.item]
-        cell.configure(title: product.name, price: product.price.currency)
+        cell.configure(
+            title: product.name, price: product.price.currency, imagePath: product.imagePath)
         return cell
     }
 

--- a/TrackMyCafe/View Layer/Flow/Settings/ProductCategories/ProductCategoriesListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/ProductCategories/ProductCategoriesListViewController.swift
@@ -51,67 +51,24 @@ final class ProductCategoriesListViewController: UIViewController, Loggable {
     }
 
     @objc private func addCategory() {
-        presentCategoryAlert(category: nil)
+        let sortOrder = (categories.map { $0.sortOrder }.max() ?? 0) + 1
+        let newCategory = ProductCategoryModel(
+            id: UUID().uuidString,
+            name: "",
+            sortOrder: sortOrder
+        )
+        showDetails(for: newCategory, isNew: true)
     }
 
-    private func presentCategoryAlert(category: ProductCategoryModel?) {
-        let isEditing = category != nil
-        let alert = UIAlertController(
-            title: isEditing
-                ? R.string.global.edit()
-                : R.string.global.add(),
-            message: nil,
-            preferredStyle: .alert
+    private func showDetails(for category: ProductCategoryModel, isNew: Bool) {
+        let title = isNew ? R.string.global.add() : R.string.global.edit()
+        let vm = ProductCategoryDetailsViewModel(
+            title: title,
+            model: category,
+            dataService: DomainProductCategoryDataService()
         )
-
-        alert.addTextField { textField in
-            textField.placeholder = R.string.global.enterProductName()
-            textField.text = category?.name
-        }
-
-        alert.addAction(
-            UIAlertAction(title: R.string.global.cancel(), style: .cancel)
-        )
-
-        alert.addAction(
-            UIAlertAction(title: R.string.global.save(), style: .default) { [weak self] _ in
-                guard let self = self else { return }
-                guard let name = alert.textFields?.first?.text, !name.isEmpty else { return }
-
-                if var existing = category {
-                    existing.name = name
-                    DomainDatabaseService.shared.saveProductCategory(category: existing) {
-                        success in
-                        if success {
-                            self.logger.notice(
-                                "Product category \(existing.id) updated successfully")
-                            self.loadData()
-                        } else {
-                            self.logger.error("Failed to update product category \(existing.id)")
-                        }
-                    }
-                } else {
-                    let sortOrder = (self.categories.map { $0.sortOrder }.max() ?? 0) + 1
-                    let newCategory = ProductCategoryModel(
-                        id: UUID().uuidString,
-                        name: name,
-                        sortOrder: sortOrder
-                    )
-                    DomainDatabaseService.shared.saveProductCategory(category: newCategory) {
-                        success in
-                        if success {
-                            self.logger.notice(
-                                "Product category \(newCategory.id) created successfully")
-                            self.loadData()
-                        } else {
-                            self.logger.error("Failed to create product category \(newCategory.id)")
-                        }
-                    }
-                }
-            }
-        )
-
-        present(alert, animated: true)
+        let vc = ProductCategoryDetailsViewController(viewModel: vm)
+        navigationController?.pushViewController(vc, animated: true)
     }
 }
 
@@ -131,7 +88,14 @@ extension ProductCategoriesListViewController: UITableViewDataSource, UITableVie
         let category = categories[indexPath.row]
         var content = cell.defaultContentConfiguration()
         content.text = category.name
+        let placeholder = AppImagePlaceholder.category()
+        content.image = placeholder
         cell.contentConfiguration = content
+
+        cell.imageView?.contentMode = .scaleAspectFill
+        cell.imageView?.clipsToBounds = true
+        cell.imageView?.setImage(pathOrURL: category.imagePath, placeholder: placeholder)
+
         return cell
     }
 
@@ -149,6 +113,11 @@ extension ProductCategoriesListViewController: UITableViewDataSource, UITableVie
             DomainDatabaseService.shared.deleteProductCategory(model: model) { success in
                 if success {
                     self.logger.notice("Product category \(model.id) deleted successfully")
+                    Task {
+                        _ = try? await FirebaseImageStorageService.shared.delete(
+                            atPath: ImageStoragePaths.productCategoryImagePath(categoryId: model.id)
+                        )
+                    }
                     self.loadData()
                 } else {
                     self.logger.error("Failed to delete product category \(model.id)")
@@ -162,6 +131,6 @@ extension ProductCategoriesListViewController: UITableViewDataSource, UITableVie
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let category = categories[indexPath.row]
-        presentCategoryAlert(category: category)
+        showDetails(for: category, isNew: false)
     }
 }

--- a/TrackMyCafe/View Layer/Flow/Settings/ProductCategories/ProductCategoryDetailsViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/ProductCategories/ProductCategoryDetailsViewController.swift
@@ -1,0 +1,301 @@
+import PhotosUI
+import TinyConstraints
+import UIKit
+
+final class ProductCategoryDetailsViewController: UIViewController, Loggable {
+    private let viewModel: ProductCategoryDetailsViewModelType
+    private var isImagePresent: Bool = false
+    private var isSaving = false
+
+    private lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.keyboardDismissMode = .onDrag
+        return scrollView
+    }()
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = UIConstants.standardPadding
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        return stackView
+    }()
+
+    private lazy var imageView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 12
+        view.isUserInteractionEnabled = true
+        view.backgroundColor = UIColor.TabBar.tint.alpha(0.12)
+        view.accessibilityTraits = [.image]
+        return view
+    }()
+
+    private lazy var imageLoadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
+    private lazy var nameInputContainer: InputContainerView = {
+        let container = InputContainerView(
+            labelText: R.string.global.productCategories(),
+            inputType: .text(keyboardType: .default),
+            isEditable: true,
+            placeholder: R.string.global.enterProductName()
+        )
+        container.setReturnKeyType(.done)
+        container.setDelegate(self)
+        return container
+    }()
+
+    private lazy var saveButton: UIButton = {
+        let button = DefaultButton()
+        button.setTitle(R.string.global.save(), for: .normal)
+        button.addTarget(self, action: #selector(saveTapped), for: .touchUpInside)
+        return button
+    }()
+
+    init(viewModel: ProductCategoryDetailsViewModelType) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        return nil
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor.Main.background
+        title = viewModel.title
+
+        view.addSubview(scrollView)
+        view.addSubview(saveButton)
+        scrollView.addSubview(stackView)
+
+        stackView.addArrangedSubview(imageView)
+        stackView.addArrangedSubview(nameInputContainer)
+        imageView.addSubview(imageLoadingIndicator)
+
+        imageView.height(180)
+        imageLoadingIndicator.centerInSuperview()
+        nameInputContainer.height(
+            UIConstants.cellHeight + UIConstants.largeSpacing + UIConstants.standardPadding)
+
+        scrollView.edgesToSuperview(excluding: .bottom, usingSafeArea: true)
+        scrollView.bottomToTop(of: saveButton, offset: -UIConstants.standardPadding)
+
+        let horizontalInset = UIConstants.standardPadding
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        let fillWidth = stackView.widthAnchor.constraint(
+            equalTo: scrollView.frameLayoutGuide.widthAnchor,
+            constant: -2 * horizontalInset
+        )
+        fillWidth.priority = .defaultHigh
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.topAnchor,
+                constant: UIConstants.largeSpacing
+            ),
+            stackView.bottomAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.bottomAnchor,
+                constant: -UIConstants.largeSpacing
+            ),
+            stackView.centerXAnchor.constraint(equalTo: scrollView.frameLayoutGuide.centerXAnchor),
+            stackView.leadingAnchor.constraint(
+                greaterThanOrEqualTo: scrollView.frameLayoutGuide.leadingAnchor,
+                constant: horizontalInset
+            ),
+            stackView.trailingAnchor.constraint(
+                lessThanOrEqualTo: scrollView.frameLayoutGuide.trailingAnchor,
+                constant: -horizontalInset
+            ),
+            fillWidth,
+            stackView.widthAnchor.constraint(lessThanOrEqualToConstant: 560),
+        ])
+
+        saveButton.horizontalToSuperview(insets: .horizontal(UIConstants.standardPadding))
+        saveButton.height(UIConstants.buttonHeight)
+        let saveBottom = saveButton.bottomAnchor.constraint(
+            equalTo: view.keyboardLayoutGuide.topAnchor,
+            constant: -UIConstants.standardPadding
+        )
+        saveBottom.isActive = true
+
+        imageView.addGestureRecognizer(
+            UITapGestureRecognizer(target: self, action: #selector(imageTapped)))
+
+        nameInputContainer.text = viewModel.name
+        applyInitialImage()
+    }
+
+    private func applyInitialImage() {
+        let placeholder = AppImagePlaceholder.category()
+        if let path = viewModel.imagePath, !path.isEmpty {
+            isImagePresent = true
+            imageView.setImage(pathOrURL: path, placeholder: placeholder)
+        } else {
+            isImagePresent = false
+            imageView.image = placeholder
+        }
+    }
+
+    @objc private func imageTapped() {
+        guard !isSaving else { return }
+        let alert = UIAlertController(
+            title: nil,
+            message: nil,
+            preferredStyle: .actionSheet
+        )
+
+        alert.addAction(
+            UIAlertAction(title: R.string.global.gallery(), style: .default) { [weak self] _ in
+                self?.presentPhotoPicker()
+            }
+        )
+
+        if isImagePresent {
+            alert.addAction(
+                UIAlertAction(title: R.string.global.delete(), style: .destructive) {
+                    [weak self] _ in
+                    self?.viewModel.markImageDeleted()
+                    self?.applyInitialImage()
+                }
+            )
+        }
+
+        alert.addAction(UIAlertAction(title: R.string.global.cancel(), style: .cancel))
+
+        if let popover = alert.popoverPresentationController {
+            popover.sourceView = imageView
+            popover.sourceRect = imageView.bounds
+        }
+
+        present(alert, animated: true)
+    }
+
+    private func presentPhotoPicker() {
+        var config = PHPickerConfiguration(photoLibrary: .shared())
+        config.selectionLimit = 1
+        config.filter = .images
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+
+    @objc private func saveTapped() {
+        view.endEditing(true)
+        setSavingState(true)
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                self.viewModel.setName(self.nameInputContainer.text)
+                try await self.viewModel.save()
+                _ = await MainActor.run {
+                    self.navigationController?.popViewController(animated: true)
+                }
+            } catch {
+                _ = await MainActor.run {
+                    let description =
+                        error.localizedDescription.isEmpty
+                        ? R.string.global.failedToSaveProductCategory()
+                        : error.localizedDescription
+                    PopupFactory.showPopup(
+                        title: R.string.global.error(),
+                        description: description
+                    ) {}
+                }
+            }
+            _ = await MainActor.run {
+                self.setSavingState(false)
+            }
+        }
+    }
+
+    private func setSavingState(_ isSaving: Bool) {
+        self.isSaving = isSaving
+        saveButton.isEnabled = !isSaving
+        saveButton.setTitle(
+            isSaving ? R.string.global.loading() : R.string.global.save(),
+            for: .normal
+        )
+    }
+
+    private func setImageLoading(_ isLoading: Bool) {
+        imageView.isUserInteractionEnabled = !isLoading && !isSaving
+        if isLoading {
+            imageLoadingIndicator.startAnimating()
+        } else {
+            imageLoadingIndicator.stopAnimating()
+        }
+    }
+
+    private func makeJPEGData(from image: UIImage) -> Data? {
+        let maxDimension: CGFloat = 1400
+        let size = image.size
+        let longestSide = max(size.width, size.height)
+        guard longestSide > 0 else { return nil }
+        let scale = min(1, maxDimension / longestSide)
+        let targetSize = CGSize(width: size.width * scale, height: size.height * scale)
+
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        let rendered = renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: targetSize))
+        }
+        return rendered.jpegData(compressionQuality: 0.86)
+    }
+}
+
+extension ProductCategoryDetailsViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+}
+
+extension ProductCategoryDetailsViewController: PHPickerViewControllerDelegate {
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true)
+
+        guard let item = results.first?.itemProvider else { return }
+
+        Task { [weak self] in
+            guard let self else { return }
+            await MainActor.run {
+                self.setImageLoading(true)
+            }
+            defer {
+                Task { @MainActor [weak self] in
+                    self?.setImageLoading(false)
+                }
+            }
+            let image = await self.loadImage(from: item)
+            guard let image else { return }
+
+            let data = self.makeJPEGData(from: image)
+            guard let data else { return }
+
+            self.viewModel.setSelectedImageData(data)
+            _ = await MainActor.run {
+                self.imageView.image = image
+                self.isImagePresent = true
+            }
+        }
+    }
+
+    private func loadImage(from provider: NSItemProvider) async -> UIImage? {
+        await withCheckedContinuation { continuation in
+            if provider.canLoadObject(ofClass: UIImage.self) {
+                provider.loadObject(ofClass: UIImage.self) { object, _ in
+                    continuation.resume(returning: object as? UIImage)
+                }
+            } else {
+                continuation.resume(returning: nil)
+            }
+        }
+    }
+}

--- a/TrackMyCafe/View Layer/Flow/Settings/ProductCategories/ProductCategoryDetailsViewModel.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/ProductCategories/ProductCategoryDetailsViewModel.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+final class ProductCategoryDetailsViewModel: ProductCategoryDetailsViewModelType, Loggable {
+    private enum ImageUpdate {
+        case unchanged
+        case delete
+        case replace(Data)
+    }
+
+    private let screenTitle: String
+    private var model: ProductCategoryModel
+    private let dataService: ProductCategoryDataServiceProtocol
+    private let imageStorage: ImageStorageServiceProtocol
+
+    private var imageUpdate: ImageUpdate = .unchanged
+
+    init(
+        title: String,
+        model: ProductCategoryModel,
+        dataService: ProductCategoryDataServiceProtocol,
+        imageStorage: ImageStorageServiceProtocol = FirebaseImageStorageService.shared
+    ) {
+        self.screenTitle = title
+        self.model = model
+        self.dataService = dataService
+        self.imageStorage = imageStorage
+    }
+
+    var title: String { screenTitle }
+    var name: String { model.name }
+    var imagePath: String? { model.imagePath }
+
+    func setName(_ name: String?) {
+        model.name = (name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func setSelectedImageData(_ data: Data?) {
+        guard let data else { return }
+        imageUpdate = .replace(data)
+    }
+
+    func markImageDeleted() {
+        let hadPersistedImage = (model.imagePath?.isEmpty == false)
+        imageUpdate = hadPersistedImage ? .delete : .unchanged
+        model.imagePath = nil
+    }
+
+    @MainActor
+    func save() async throws {
+        let trimmedName = model.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { throw DomainProductCategoryError.saveFailed }
+        model.name = trimmedName
+
+        var pendingDeletePath: String?
+
+        switch imageUpdate {
+        case .unchanged:
+            break
+        case .delete:
+            pendingDeletePath = model.imagePath
+            model.imagePath = nil
+        case .replace(let data):
+            let path = ImageStoragePaths.productCategoryImagePath(categoryId: model.id)
+            do {
+                try await imageStorage.upload(data: data, toPath: path, contentType: "image/jpeg")
+            } catch {
+                logger.error(
+                    "Product category image upload failed for \(self.model.id): \(error.localizedDescription)"
+                )
+                throw NSError(
+                    domain: "ProductCategoryImageUpload",
+                    code: 1,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Image upload failed: \(error.localizedDescription)"
+                    ]
+                )
+            }
+            model.imagePath = path
+        }
+
+        do {
+            try await dataService.saveCategory(model)
+        } catch {
+            logger.error("Failed to save product category \(self.model.id): \(error.localizedDescription)")
+            throw NSError(
+                domain: "ProductCategoryFirestoreSave",
+                code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Firestore save failed: \(error.localizedDescription)"
+                ]
+            )
+        }
+
+        if let pendingDeletePath {
+            Task {
+                _ = try? await self.imageStorage.delete(atPath: pendingDeletePath)
+            }
+        }
+        imageUpdate = .unchanged
+    }
+}

--- a/TrackMyCafe/View Layer/Flow/Settings/ProductCategories/ProductCategoryDetailsViewModelType.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/ProductCategories/ProductCategoryDetailsViewModelType.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+protocol ProductCategoryDetailsViewModelType: AnyObject {
+    var title: String { get }
+    var name: String { get }
+    var imagePath: String? { get }
+
+    func setName(_ name: String?)
+    func setSelectedImageData(_ data: Data?)
+    func markImageDeleted()
+    func save() async throws
+}
+

--- a/TrackMyCafe/View Layer/Flow/Settings/Products/ProductDetail/View/ProductDetailsViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/Products/ProductDetail/View/ProductDetailsViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Леонід Квіт on 27.11.2021.
 //
 
+import PhotosUI
 import TinyConstraints
 import UIKit
 
@@ -25,6 +26,17 @@ class ProductDetailsViewController: UIViewController {
         stackView.distribution = .fill
         stackView.alignment = .fill
         return stackView
+    }()
+
+    private lazy var productImageView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 12
+        view.isUserInteractionEnabled = true
+        view.backgroundColor = UIColor.TabBar.tint.alpha(0.12)
+        view.accessibilityTraits = [.image]
+        return view
     }()
 
     // MARK: - Inputs
@@ -103,6 +115,14 @@ class ProductDetailsViewController: UIViewController {
 
     private let viewModel: ProductDetailsViewModelType
     private var categories: [ProductCategoryModel] = []
+    private var isImagePresent: Bool = false
+    private var isSaving = false
+
+    private lazy var imageLoadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
 
     init(viewModel: ProductDetailsViewModelType) {
         self.viewModel = viewModel
@@ -153,6 +173,7 @@ class ProductDetailsViewController: UIViewController {
         priceInputContainer.setReturnKeyType(.done)
 
         // Add containers to stack
+        mainStackView.addArrangedSubview(productImageView)
         mainStackView.addArrangedSubview(nameInputContainer)
         mainStackView.addArrangedSubview(priceInputContainer)
         mainStackView.addArrangedSubview(categoryInputContainer)
@@ -161,6 +182,12 @@ class ProductDetailsViewController: UIViewController {
         mainStackView.addArrangedSubview(recipeTitleLabel)
         mainStackView.addArrangedSubview(recipeTableView)
         mainStackView.addArrangedSubview(addIngredientButton)
+
+        productImageView.addGestureRecognizer(
+            UITapGestureRecognizer(target: self, action: #selector(imageTapped))
+        )
+        productImageView.addSubview(imageLoadingIndicator)
+        imageLoadingIndicator.centerInSuperview()
     }
 
     private func updateRecipeUI() {
@@ -204,7 +231,8 @@ class ProductDetailsViewController: UIViewController {
                 equalTo: scrollView.contentLayoutGuide.bottomAnchor,
                 constant: -UIConstants.largeSpacing
             ),
-            mainStackView.centerXAnchor.constraint(equalTo: scrollView.frameLayoutGuide.centerXAnchor),
+            mainStackView.centerXAnchor.constraint(
+                equalTo: scrollView.frameLayoutGuide.centerXAnchor),
             mainStackView.leadingAnchor.constraint(
                 greaterThanOrEqualTo: scrollView.frameLayoutGuide.leadingAnchor,
                 constant: horizontalInset
@@ -220,12 +248,14 @@ class ProductDetailsViewController: UIViewController {
         // Container heights
         let containerHeight =
             UIConstants.cellHeight + UIConstants.largeSpacing + UIConstants.standardPadding
+        productImageView.height(180)
         nameInputContainer.height(containerHeight)
         priceInputContainer.height(containerHeight)
         categoryInputContainer.height(containerHeight)
         addIngredientButton.height(UIConstants.buttonHeight)
 
-        recipeTableViewHeightConstraint = recipeTableView.heightAnchor.constraint(equalToConstant: 0)
+        recipeTableViewHeightConstraint = recipeTableView.heightAnchor.constraint(
+            equalToConstant: 0)
         recipeTableViewHeightConstraint?.isActive = true
 
         // Save button constraints
@@ -260,6 +290,73 @@ class ProductDetailsViewController: UIViewController {
                 self?.updateCategorySelection()
             }
         }
+
+        applyInitialImage()
+    }
+
+    private func applyInitialImage() {
+        let placeholder = AppImagePlaceholder.product()
+        if let path = viewModel.imagePath, !path.isEmpty {
+            isImagePresent = true
+            productImageView.setImage(pathOrURL: path, placeholder: placeholder)
+        } else {
+            isImagePresent = false
+            productImageView.image = placeholder
+        }
+    }
+
+    @objc private func imageTapped() {
+        guard !isSaving else { return }
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+        alert.addAction(
+            UIAlertAction(title: R.string.global.gallery(), style: .default) { [weak self] _ in
+                self?.presentPhotoPicker()
+            }
+        )
+
+        if isImagePresent {
+            alert.addAction(
+                UIAlertAction(title: R.string.global.delete(), style: .destructive) {
+                    [weak self] _ in
+                    self?.viewModel.markImageDeleted()
+                    self?.applyInitialImage()
+                }
+            )
+        }
+
+        alert.addAction(UIAlertAction(title: R.string.global.cancel(), style: .cancel))
+
+        if let popover = alert.popoverPresentationController {
+            popover.sourceView = productImageView
+            popover.sourceRect = productImageView.bounds
+        }
+
+        present(alert, animated: true)
+    }
+
+    private func presentPhotoPicker() {
+        var config = PHPickerConfiguration(photoLibrary: .shared())
+        config.selectionLimit = 1
+        config.filter = .images
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+
+    private func makeJPEGData(from image: UIImage) -> Data? {
+        let maxDimension: CGFloat = 1400
+        let size = image.size
+        let longestSide = max(size.width, size.height)
+        guard longestSide > 0 else { return nil }
+        let scale = min(1, maxDimension / longestSide)
+        let targetSize = CGSize(width: size.width * scale, height: size.height * scale)
+
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        let rendered = renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: targetSize))
+        }
+        return rendered.jpegData(compressionQuality: 0.86)
     }
 
     private func updateCategorySelection() {
@@ -287,7 +384,8 @@ class ProductDetailsViewController: UIViewController {
         let toolbar = UIToolbar()
         toolbar.sizeToFit()
 
-        let flexSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let flexSpace = UIBarButtonItem(
+            barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         let doneButton = UIBarButtonItem(
             title: R.string.global.actionOk(),
             style: .done,
@@ -346,7 +444,8 @@ class ProductDetailsViewController: UIViewController {
             alert.addAction(
                 UIAlertAction(title: R.string.global.actionOk(), style: .default, handler: nil))
             alert.addAction(
-                UIAlertAction(title: R.string.global.actionGoToSettings(), style: .default) { [weak self] _ in
+                UIAlertAction(title: R.string.global.actionGoToSettings(), style: .default) {
+                    [weak self] _ in
                     self?.navigationController?.popToRootViewController(animated: true)
                 })
 
@@ -365,7 +464,8 @@ class ProductDetailsViewController: UIViewController {
                 })
         }
 
-        alert.addAction(UIAlertAction(title: R.string.global.cancel(), style: .cancel, handler: nil))
+        alert.addAction(
+            UIAlertAction(title: R.string.global.cancel(), style: .cancel, handler: nil))
 
         if let popoverController = alert.popoverPresentationController {
             popoverController.sourceView = addIngredientButton
@@ -376,8 +476,10 @@ class ProductDetailsViewController: UIViewController {
     }
 
     private func showQuantityInput(for ingredient: IngredientModel) {
-        let message = R.string.global.enterQuantityPerUnit() + " (" + ingredient.unit.localizedName + ")"
-        let alert = UIAlertController(title: ingredient.name, message: message, preferredStyle: .alert)
+        let message =
+            R.string.global.enterQuantityPerUnit() + " (" + ingredient.unit.localizedName + ")"
+        let alert = UIAlertController(
+            title: ingredient.name, message: message, preferredStyle: .alert)
 
         alert.addTextField { (textField: UITextField) in
             textField.keyboardType = UIKeyboardType.decimalPad
@@ -413,7 +515,8 @@ class ProductDetailsViewController: UIViewController {
                         UIAlertAction(title: R.string.global.no(), style: .cancel, handler: nil))
                     self.present(overwriteAlert, animated: true)
                 } else {
-                    self.viewModel.addRecipeItem(ingredient: ingredient, quantity: quantity, overwrite: false)
+                    self.viewModel.addRecipeItem(
+                        ingredient: ingredient, quantity: quantity, overwrite: false)
                 }
             })
 
@@ -441,7 +544,7 @@ class ProductDetailsViewController: UIViewController {
 
         let parsedPrice = viewModel.parsedPrice(from: priceText) ?? 0.0
 
-        saveButton.isEnabled = false
+        setSavingState(true)
         Task { [weak self] in
             guard let self = self else { return }
             do {
@@ -451,15 +554,38 @@ class ProductDetailsViewController: UIViewController {
                 }
             } catch {
                 _ = await MainActor.run {
+                    let description =
+                        error.localizedDescription.isEmpty
+                        ? R.string.global.failedToSaveProductPrice()
+                        : error.localizedDescription
                     PopupFactory.showPopup(
                         title: R.string.global.error(),
-                        description: R.string.global.failedToSaveProductPrice()
+                        description: description
                     ) {}
                 }
             }
             _ = await MainActor.run {
-                self.saveButton.isEnabled = true
+                self.setSavingState(false)
             }
+        }
+    }
+
+    private func setSavingState(_ isSaving: Bool) {
+        self.isSaving = isSaving
+        saveButton.isEnabled = !isSaving
+        saveButton.setTitle(
+            isSaving ? R.string.global.loading() : R.string.global.save(),
+            for: .normal
+        )
+        productImageView.isUserInteractionEnabled = !isSaving
+    }
+
+    private func setImageLoading(_ isLoading: Bool) {
+        productImageView.isUserInteractionEnabled = !isLoading && !isSaving
+        if isLoading {
+            imageLoadingIndicator.startAnimating()
+        } else {
+            imageLoadingIndicator.stopAnimating()
         }
     }
 
@@ -500,7 +626,8 @@ extension ProductDetailsViewController: UITextFieldDelegate {
         // Check if it's the alert text field. Since we don't have a direct reference to the alert text field here easily without storing it,
         // we can check if it is NOT one of our known properties.
         if textField == nameInputContainer.textFieldReference
-            || textField == priceInputContainer.textFieldReference {
+            || textField == priceInputContainer.textFieldReference
+        {
             return true
         }
 
@@ -548,6 +675,49 @@ extension ProductDetailsViewController: UITableViewDataSource, UITableViewDelega
     ) {
         if editingStyle == .delete {
             viewModel.removeRecipeItem(at: indexPath.row)
+        }
+    }
+}
+
+extension ProductDetailsViewController: PHPickerViewControllerDelegate {
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true)
+
+        guard let item = results.first?.itemProvider else { return }
+
+        Task { [weak self] in
+            guard let self else { return }
+            await MainActor.run {
+                self.setImageLoading(true)
+            }
+            defer {
+                Task { @MainActor [weak self] in
+                    self?.setImageLoading(false)
+                }
+            }
+            let image = await self.loadImage(from: item)
+            guard let image else { return }
+
+            let data = self.makeJPEGData(from: image)
+            guard let data else { return }
+
+            self.viewModel.setSelectedImageData(data)
+            _ = await MainActor.run {
+                self.productImageView.image = image
+                self.isImagePresent = true
+            }
+        }
+    }
+
+    private func loadImage(from provider: NSItemProvider) async -> UIImage? {
+        await withCheckedContinuation { continuation in
+            if provider.canLoadObject(ofClass: UIImage.self) {
+                provider.loadObject(ofClass: UIImage.self) { object, _ in
+                    continuation.resume(returning: object as? UIImage)
+                }
+            } else {
+                continuation.resume(returning: nil)
+            }
         }
     }
 }

--- a/TrackMyCafe/View Layer/Flow/Settings/Products/ProductDetail/ViewModel/ProductDetailsViewModel.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/Products/ProductDetail/ViewModel/ProductDetailsViewModel.swift
@@ -8,29 +8,52 @@
 import Foundation
 
 final class ProductDetailsViewModel: ProductDetailsViewModelType, Loggable {
+    private enum ImageUpdate {
+        case unchanged
+        case delete
+        case replace(Data)
+    }
+
     private var model: ProductsPriceModel
     private let dataService: ProductPriceDataServiceProtocol
     private let ingredientService: IngredientDataServiceProtocol
-    
+    private let imageStorage: ImageStorageServiceProtocol
+
+    private var imageUpdate: ImageUpdate = .unchanged
+
     var productName: String { model.name }
     var productPrice: Double { model.price }
     var currentRecipe: [RecipeItemModel] { model.recipe }
     var allIngredients: [IngredientModel] = []
     var categoryId: String? { model.categoryId }
-    
+    var imagePath: String? { model.imagePath }
+
     var onRecipeChanged: (() -> Void)?
     var onIngredientsLoaded: (() -> Void)?
-    
+
     init(
         model: ProductsPriceModel,
         dataService: ProductPriceDataServiceProtocol,
-        ingredientService: IngredientDataServiceProtocol = DomainIngredientDataService.shared
+        ingredientService: IngredientDataServiceProtocol = DomainIngredientDataService.shared,
+        imageStorage: ImageStorageServiceProtocol = FirebaseImageStorageService.shared
     ) {
         self.model = model
         self.dataService = dataService
         self.ingredientService = ingredientService
+        self.imageStorage = imageStorage
     }
-    
+
+    func setSelectedImageData(_ data: Data?) {
+        guard let data else { return }
+        imageUpdate = .replace(data)
+    }
+
+    func markImageDeleted() {
+        let hadPersistedImage = (model.imagePath?.isEmpty == false)
+        imageUpdate = hadPersistedImage ? .delete : .unchanged
+        model.imagePath = nil
+    }
+
     func fetchIngredients() async {
         do {
             let ingredients = try await ingredientService.fetchIngredients()
@@ -42,14 +65,14 @@ final class ProductDetailsViewModel: ProductDetailsViewModelType, Loggable {
             logger.error("Failed to fetch ingredients: \(error)")
         }
     }
-    
+
     func hasIngredient(_ ingredient: IngredientModel) -> Bool {
         return model.recipe.contains(where: { $0.ingredientId == ingredient.id })
     }
-    
+
     func addRecipeItem(ingredient: IngredientModel, quantity: Double, overwrite: Bool = false) {
         guard quantity > 0 else { return }
-        
+
         if let index = model.recipe.firstIndex(where: { $0.ingredientId == ingredient.id }) {
             if overwrite {
                 var existingItem = model.recipe[index]
@@ -65,13 +88,13 @@ final class ProductDetailsViewModel: ProductDetailsViewModelType, Loggable {
             onRecipeChanged?()
         }
     }
-    
+
     func removeRecipeItem(at index: Int) {
         guard index >= 0 && index < model.recipe.count else { return }
         model.recipe.remove(at: index)
         onRecipeChanged?()
     }
-    
+
     func updateRecipeItem(at index: Int, quantity: Double) {
         guard index >= 0 && index < model.recipe.count else { return }
         var item = model.recipe[index]
@@ -79,11 +102,11 @@ final class ProductDetailsViewModel: ProductDetailsViewModelType, Loggable {
         model.recipe[index] = item
         onRecipeChanged?()
     }
-    
+
     func setCategoryId(_ id: String?) {
         model.categoryId = id
     }
-    
+
     func validate(name: String?, priceText: String?) -> Bool {
         guard let name = name, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return false
@@ -91,7 +114,7 @@ final class ProductDetailsViewModel: ProductDetailsViewModelType, Loggable {
         guard let price = parsedPrice(from: priceText), price >= 0 else { return false }
         return true
     }
-    
+
     func parsedPrice(from text: String?) -> Double? {
         guard let text = text, !text.isEmpty else { return nil }
         let formatter = NumberFormatter()
@@ -100,27 +123,74 @@ final class ProductDetailsViewModel: ProductDetailsViewModelType, Loggable {
         if let number = formatter.number(from: text)?.doubleValue { return number }
         return Double(text.replacingOccurrences(of: ",", with: "."))
     }
-    
+
     @MainActor
     func saveProductPrice(name: String?, price: Double?) async throws {
         let nameValue = (name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let priceValue = price ?? 0.0
-        
+
         model.name = nameValue
         model.price = priceValue
-        
-        if model.id.isEmpty {
+
+        let isNew = model.id.isEmpty
+        if isNew {
             model.id = UUID().uuidString
+        }
+
+        var pendingDeletePath: String?
+
+        switch imageUpdate {
+        case .unchanged:
+            break
+        case .delete:
+            pendingDeletePath = model.imagePath
+            model.imagePath = nil
+        case .replace(let data):
+            let path = ImageStoragePaths.productImagePath(productId: model.id)
             do {
+                try await imageStorage.upload(data: data, toPath: path, contentType: "image/jpeg")
+            } catch {
+                logger.error(
+                    "Product image upload failed for \(self.model.id): \(error.localizedDescription)"
+                )
+                throw NSError(
+                    domain: "ProductImageUpload",
+                    code: 1,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Image upload failed: \(error.localizedDescription)"
+                    ]
+                )
+            }
+            model.imagePath = path
+        }
+
+        do {
+            if isNew {
                 try await dataService.saveProductPrice(model)
                 logger.notice("Product price \(model.id) saved successfully")
-            } catch {
-                logger.error("Failed to save product price \(model.id)")
-                throw error
+            } else {
+                try await dataService.updateProductPrice(model, name: nameValue, price: priceValue)
+                logger.notice("Product price \(model.id) updated successfully")
             }
-        } else {
-            await dataService.updateProductPrice(model, name: nameValue, price: priceValue)
-            logger.notice("Product price \(model.id) updated successfully")
+        } catch {
+            logger.error("Failed to save product price \(self.model.id): \(error.localizedDescription)")
+            throw NSError(
+                domain: "ProductFirestoreSave",
+                code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Firestore save failed: \(error.localizedDescription)"
+                ]
+            )
         }
+
+        if let pendingDeletePath {
+            Task {
+                _ = try? await self.imageStorage.delete(atPath: pendingDeletePath)
+            }
+        }
+
+        imageUpdate = .unchanged
     }
 }

--- a/TrackMyCafe/View Layer/Flow/Settings/Products/ProductDetail/ViewModel/ProductDetailsViewModelType.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/Products/ProductDetail/ViewModel/ProductDetailsViewModelType.swift
@@ -13,6 +13,7 @@ protocol ProductDetailsViewModelType: AnyObject {
     var currentRecipe: [RecipeItemModel] { get }
     var allIngredients: [IngredientModel] { get }
     var categoryId: String? { get }
+    var imagePath: String? { get }
     
     var onRecipeChanged: (() -> Void)? { get set }
     var onIngredientsLoaded: (() -> Void)? { get set }
@@ -21,6 +22,9 @@ protocol ProductDetailsViewModelType: AnyObject {
     func parsedPrice(from text: String?) -> Double?
     func saveProductPrice(name: String?, price: Double?) async throws
     func setCategoryId(_ id: String?)
+
+    func setSelectedImageData(_ data: Data?)
+    func markImageDeleted()
     
     func fetchIngredients() async
     func hasIngredient(_ ingredient: IngredientModel) -> Bool

--- a/TrackMyCafe/View Layer/Flow/Settings/Products/ProductList/View/Cells/ProductPriceTableViewCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/Products/ProductList/View/Cells/ProductPriceTableViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class ProductPriceTableViewCell: BaseListTableViewCell {
-    
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .value1, reuseIdentifier: reuseIdentifier)
 
@@ -16,14 +16,27 @@ final class ProductPriceTableViewCell: BaseListTableViewCell {
         accessoryType = .disclosureIndicator
         textLabel?.applyDynamic(Typography.body)
         detailTextLabel?.applyDynamic(Typography.body)
+        imageView?.contentMode = .scaleAspectFill
+        imageView?.clipsToBounds = true
     }
-    
+
     required init?(coder: NSCoder) {
         return nil
     }
-    
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageView?.cancelImageLoad()
+        imageView?.image = nil
+        textLabel?.text = nil
+        detailTextLabel?.text = nil
+    }
+
     func configure(productPrice: ProductsPriceModel, indexPath: IndexPath) {
         textLabel?.text = productPrice.name
         detailTextLabel?.text = productPrice.price.currency
+
+        let placeholder = AppImagePlaceholder.product()
+        imageView?.setImage(pathOrURL: productPrice.imagePath, placeholder: placeholder)
     }
 }

--- a/TrackMyCafe/View Layer/Flow/Settings/Products/ProductList/View/ProductListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/Products/ProductList/View/ProductListViewController.swift
@@ -198,6 +198,11 @@ extension ProductListViewController: UITableViewDelegate, UITableViewDataSource 
             DomainDatabaseService.shared.deleteProductsPrice(model: model) { [self] success in
                 if success {
                     logger.notice("productsPrice type \(model.id) deleted successfully")
+                    Task {
+                        _ = try? await FirebaseImageStorageService.shared.delete(
+                            atPath: ImageStoragePaths.productImagePath(productId: model.id)
+                        )
+                    }
                     self.configure()
                     
                     tableView.reloadData()


### PR DESCRIPTION
## Title

- feat(images): attach image to product and category

## Plan

- Add optional image metadata (path) for Category and Product.
- Upload/delete image file in Firebase Storage; store path in Firestore.
- Add local caching + async image loading.
- Add image picker + preview to Settings edit screens.
- Display images in pickers (category-first + regular) with consistent proportions.

## Code

- Models/DTO: add `imagePath` to `ProductCategoryModel` / `ProductsPriceModel` + FIR models.
- Storage: `FirebaseImageStorageService` async/await wrappers; ignores object-not-found on delete.
- Cache/loader: `ImageDataCache` + `ImageLoader` + `UIImageView.setImage(pathOrURL:)`.
- Settings:
  - Category details: new details screen with PHPicker, preview, replace/delete.
  - Product details: image picker + replace/delete + improved error surfacing.
- Orders:
  - Show category/product images in grids/tiles.
  - Unify image aspect ratio between category/product cards and reduce empty space.

## Expected outcome

- Categories and products can have an optional image.
- Settings list + details show image preview and support replace/delete.
- Order pickers show images; category/product cards use consistent image proportions.

## Validation

- No xcodebuild executed (per project rules).
- Verified via IDE diagnostics; runtime smoke tested on iPhone + iPad.
- Note: Firebase Storage must be enabled for the environment used.

## References

- Related: #204
