### PR TITLE
feat(finance): implement journal engine and daily balance materialization

### DIFF
--- a/TrackMyCafe/Data Layer/Models/Domain/OpexExpenseModel.swift
+++ b/TrackMyCafe/Data Layer/Models/Domain/OpexExpenseModel.swift
@@ -14,7 +14,7 @@ struct OpexExpenseModel: Identifiable, Codable {
     let amount: Double
     let paymentAccount: PaymentAccount?
     let note: String?
-    
+
     init(
         id: String = UUID().uuidString,
         date: Date = Date(),

--- a/TrackMyCafe/Services/Domain/DomainCostDataService.swift
+++ b/TrackMyCafe/Services/Domain/DomainCostDataService.swift
@@ -7,38 +7,521 @@
 
 import Foundation
 
-enum DomainCostError: Error {
-  case saveFailed
+enum FinanceMutationError: Error {
+    case saveFailed
+    case updateFailed
+    case deleteFailed
+    case missingIdentifier
+}
+
+struct BalanceScope: Hashable {
+    let account: PaymentAccount
+    let date: Date
+
+    init(account: PaymentAccount, date: Date) {
+        self.account = account
+        self.date = Calendar.current.startOfDay(for: date)
+    }
+}
+
+protocol BalanceJournalServiceProtocol {
+    func syncOrder(previous: OrderModel?, current: OrderModel?) async throws -> Set<BalanceScope>
+    func syncOpex(previous: OpexExpenseModel?, current: OpexExpenseModel?) async throws
+        -> Set<BalanceScope>
+}
+
+protocol DailyBalanceMaterializerProtocol {
+    func materialize(scopes: Set<BalanceScope>) async throws
+}
+
+protocol OrderDataServiceProtocol {
+    func createOrder(_ order: OrderModel) async throws -> OrderModel
+    func updateOrder(previous: OrderModel, current: OrderModel) async throws
+    func deleteOrder(_ order: OrderModel) async throws
 }
 
 protocol CostDataServiceProtocol {
-  func saveCost(_ cost: OpexExpenseModel) async throws
-  func updateCost(_ cost: OpexExpenseModel, date: Date, name: String, sum: Double) async
+    func saveCost(_ cost: OpexExpenseModel) async throws
+    func updateCost(_ cost: OpexExpenseModel, date: Date, name: String, sum: Double) async throws
+    func deleteCost(_ cost: OpexExpenseModel) async throws
+}
+
+protocol FinancePersistenceProtocol: AnyObject {
+    func saveOrder(order: OrderModel, completion: @escaping (String?) -> Void)
+    func updateOrder(_ order: OrderModel, completion: @escaping (Bool) -> Void)
+    func deleteOrder(order: OrderModel, completion: @escaping (Bool) -> Void)
+
+    func saveOpexExpense(model: OpexExpenseModel, completion: @escaping (String?) -> Void)
+    func updateOpexExpense(model: OpexExpenseModel, completion: @escaping (Bool) -> Void)
+    func deleteOpexExpense(model: OpexExpenseModel, completion: @escaping (Bool) -> Void)
+
+    func saveJournalEntry(model: JournalEntryModel, completion: @escaping (String?) -> Void)
+    func fetchJournalEntries(completion: @escaping ([JournalEntryModel]) -> Void)
+
+    func saveDailyBalance(model: DailyBalanceModel, completion: @escaping (Bool) -> Void)
+    func fetchDailyBalances(
+        forAccount account: PaymentAccount,
+        from startDate: Date,
+        to endDate: Date,
+        completion: @escaping ([DailyBalanceModel]) -> Void
+    )
+
+    func delete(collection: String, documentId: String, completion: @escaping (Bool) -> Void)
+}
+
+extension DomainDatabaseService: FinancePersistenceProtocol {}
+
+final class BalanceJournalService: BalanceJournalServiceProtocol, Loggable {
+    private let database: FinancePersistenceProtocol
+
+    init(database: FinancePersistenceProtocol = DomainDatabaseService.shared) {
+        self.database = database
+    }
+
+    func syncOrder(previous: OrderModel?, current: OrderModel?) async throws -> Set<BalanceScope> {
+        let sourceId = current?.id ?? previous?.id ?? ""
+        guard !sourceId.isEmpty else {
+            throw FinanceMutationError.missingIdentifier
+        }
+
+        let newEntries = makeOrderEntries(from: current)
+        return try await replaceJournalEntries(
+            sourceType: .order,
+            sourceId: sourceId,
+            newEntries: newEntries
+        )
+    }
+
+    func syncOpex(previous: OpexExpenseModel?, current: OpexExpenseModel?) async throws
+        -> Set<BalanceScope>
+    {
+        let sourceId = current?.id ?? previous?.id ?? ""
+        guard !sourceId.isEmpty else {
+            throw FinanceMutationError.missingIdentifier
+        }
+
+        let newEntries = makeOpexEntries(from: current)
+        return try await replaceJournalEntries(
+            sourceType: .opex,
+            sourceId: sourceId,
+            newEntries: newEntries
+        )
+    }
+
+    private func replaceJournalEntries(
+        sourceType: JournalSourceType,
+        sourceId: String,
+        newEntries: [JournalEntryModel]
+    ) async throws -> Set<BalanceScope> {
+        let existingEntries = await database.fetchJournalEntriesAsync()
+            .filter { $0.sourceType == sourceType && $0.sourceId == sourceId }
+        let currentEffects = currentEffects(
+            from: existingEntries, sourceType: sourceType, sourceId: sourceId)
+
+        let stornoEntries = currentEffects.compactMap { effect -> JournalEntryModel? in
+            guard !effect.amount.isApproximatelyZero else { return nil }
+
+            return JournalEntryModel(
+                date: effect.date,
+                account: effect.account,
+                amount: -effect.amount,
+                sourceType: sourceType,
+                sourceId: sourceId,
+                note: stornoNote(from: effect.note)
+            )
+        }
+
+        for entry in stornoEntries + newEntries where !entry.amount.isApproximatelyZero {
+            _ = try await database.saveJournalEntryAsync(entry)
+        }
+
+        let affectedScopes = Set(
+            stornoEntries.map { BalanceScope(account: $0.account, date: $0.date) }
+                + newEntries.map { BalanceScope(account: $0.account, date: $0.date) }
+        )
+        logger.info("Synced journal for \(sourceType.rawValue): \(sourceId)")
+        return affectedScopes
+    }
+
+    private func makeOrderEntries(from order: OrderModel?) -> [JournalEntryModel] {
+        guard let order else { return [] }
+
+        var entries: [JournalEntryModel] = []
+        if !order.cash.isApproximatelyZero {
+            entries.append(
+                JournalEntryModel(
+                    date: order.date,
+                    account: .cash,
+                    amount: order.cash,
+                    sourceType: .order,
+                    sourceId: order.id,
+                    note: order.note
+                )
+            )
+        }
+
+        if !order.card.isApproximatelyZero {
+            entries.append(
+                JournalEntryModel(
+                    date: order.date,
+                    account: .card,
+                    amount: order.card,
+                    sourceType: .order,
+                    sourceId: order.id,
+                    note: order.note
+                )
+            )
+        }
+
+        return entries
+    }
+
+    private func makeOpexEntries(from expense: OpexExpenseModel?) -> [JournalEntryModel] {
+        guard let expense, let account = expense.paymentAccount, !expense.amount.isApproximatelyZero
+        else {
+            return []
+        }
+
+        return [
+            JournalEntryModel(
+                date: expense.date,
+                account: account,
+                amount: -expense.amount,
+                sourceType: .opex,
+                sourceId: expense.id,
+                note: expense.note
+            )
+        ]
+    }
+
+    private func currentEffects(
+        from entries: [JournalEntryModel],
+        sourceType: JournalSourceType,
+        sourceId: String
+    ) -> [(date: Date, account: PaymentAccount, amount: Double, note: String?)] {
+        let grouped = Dictionary(grouping: entries) { entry in
+            BalanceScope(account: entry.account, date: entry.date)
+        }
+
+        return grouped.compactMap { scope, items in
+            let amount = items.reduce(0) { $0 + $1.amount }
+            guard !amount.isApproximatelyZero else { return nil }
+
+            return (
+                date: scope.date,
+                account: scope.account,
+                amount: amount,
+                note: items.last?.note
+            )
+        }
+    }
+
+    private func stornoNote(from note: String?) -> String? {
+        guard let note, !note.isEmpty else { return "Storno" }
+        return "Storno: \(note)"
+    }
+}
+
+final class DailyBalanceMaterializer: DailyBalanceMaterializerProtocol, Loggable {
+    private let database: FinancePersistenceProtocol
+    private let upperBoundDate = Date(timeIntervalSince1970: 4_102_444_800)  // 2100-01-01
+
+    init(database: FinancePersistenceProtocol = DomainDatabaseService.shared) {
+        self.database = database
+    }
+
+    func materialize(scopes: Set<BalanceScope>) async throws {
+        guard !scopes.isEmpty else { return }
+
+        let journalEntries = await database.fetchJournalEntriesAsync()
+        let groupedScopes = Dictionary(grouping: scopes, by: \.account)
+
+        for (account, accountScopes) in groupedScopes {
+            guard let startDate = accountScopes.map(\.date).min() else { continue }
+
+            let accountEntries = journalEntries.filter { $0.account == account }
+            let deltaByDate = Dictionary(grouping: accountEntries) {
+                Calendar.current.startOfDay(for: $0.date)
+            }.mapValues { entries in
+                entries.reduce(0) { $0 + $1.amount }
+            }.filter { !$0.value.isApproximatelyZero }
+
+            let existingBalances = await database.fetchDailyBalancesAsync(
+                forAccount: account,
+                from: startDate,
+                to: upperBoundDate
+            )
+            let existingBalanceIds = Dictionary(
+                uniqueKeysWithValues: existingBalances.map {
+                    (Calendar.current.startOfDay(for: $0.date), $0.id)
+                }
+            )
+
+            let datesToProcess = Set(existingBalances.map(\.date)).union(deltaByDate.keys).sorted()
+            var runningBalance =
+                accountEntries
+                .filter { Calendar.current.startOfDay(for: $0.date) < startDate }
+                .reduce(0) { $0 + $1.amount }
+
+            for date in datesToProcess {
+                let normalizedDate = Calendar.current.startOfDay(for: date)
+
+                if let delta = deltaByDate[normalizedDate] {
+                    runningBalance += delta
+                    try await database.saveDailyBalanceAsync(
+                        DailyBalanceModel(
+                            date: normalizedDate,
+                            account: account,
+                            balance: runningBalance,
+                            delta: delta
+                        )
+                    )
+                } else if let existingId = existingBalanceIds[normalizedDate] {
+                    try await database.deleteDocumentAsync(
+                        collection: FirebaseCollections.dailyBalances,
+                        documentId: existingId
+                    )
+                }
+            }
+        }
+
+        logger.info("Materialized daily balances for \(scopes.count) scope(s)")
+    }
+}
+
+final class DomainOrderDataService: OrderDataServiceProtocol {
+    private let database: FinancePersistenceProtocol
+    private let balanceJournalService: BalanceJournalServiceProtocol
+    private let dailyBalanceMaterializer: DailyBalanceMaterializerProtocol
+
+    init(
+        database: FinancePersistenceProtocol = DomainDatabaseService.shared,
+        balanceJournalService: BalanceJournalServiceProtocol? = nil,
+        dailyBalanceMaterializer: DailyBalanceMaterializerProtocol? = nil
+    ) {
+        self.database = database
+        self.balanceJournalService =
+            balanceJournalService ?? BalanceJournalService(database: database)
+        self.dailyBalanceMaterializer =
+            dailyBalanceMaterializer ?? DailyBalanceMaterializer(database: database)
+    }
+
+    func createOrder(_ order: OrderModel) async throws -> OrderModel {
+        let savedOrderId = try await database.saveOrderAsync(order: order)
+        let savedOrder = OrderModel(
+            id: savedOrderId,
+            date: order.date,
+            type: order.type,
+            sum: order.sum,
+            cash: order.cash,
+            card: order.card,
+            totalCost: order.totalCost,
+            note: order.note
+        )
+
+        let scopes = try await balanceJournalService.syncOrder(previous: nil, current: savedOrder)
+        try await dailyBalanceMaterializer.materialize(scopes: scopes)
+        return savedOrder
+    }
+
+    func updateOrder(previous: OrderModel, current: OrderModel) async throws {
+        try await database.updateOrderAsync(current)
+        let scopes = try await balanceJournalService.syncOrder(previous: previous, current: current)
+        try await dailyBalanceMaterializer.materialize(scopes: scopes)
+    }
+
+    func deleteOrder(_ order: OrderModel) async throws {
+        try await database.deleteOrderAsync(order: order)
+        let scopes = try await balanceJournalService.syncOrder(previous: order, current: nil)
+        try await dailyBalanceMaterializer.materialize(scopes: scopes)
+    }
 }
 
 final class DomainCostDataService: CostDataServiceProtocol {
-  @MainActor
-  func saveCost(_ cost: OpexExpenseModel) async throws {
-    try await withCheckedThrowingContinuation { continuation in
-      DomainDatabaseService.shared.saveOpexExpense(model: cost) { id in
-        if id != nil {
-          continuation.resume()
-        } else {
-          continuation.resume(throwing: DomainCostError.saveFailed)
-        }
-      }
-    }
-  }
+    private let database: FinancePersistenceProtocol
+    private let balanceJournalService: BalanceJournalServiceProtocol
+    private let dailyBalanceMaterializer: DailyBalanceMaterializerProtocol
 
-  @MainActor
-  func updateCost(_ cost: OpexExpenseModel, date: Date, name: String, sum: Double) async {
-      let updatedCost = OpexExpenseModel(
-          id: cost.id,
-          date: date,
-          categoryId: cost.categoryId,
-          amount: sum,
-          note: name
-      )
-      DomainDatabaseService.shared.updateOpexExpense(model: updatedCost)
-  }
+    init(
+        database: FinancePersistenceProtocol = DomainDatabaseService.shared,
+        balanceJournalService: BalanceJournalServiceProtocol? = nil,
+        dailyBalanceMaterializer: DailyBalanceMaterializerProtocol? = nil
+    ) {
+        self.database = database
+        self.balanceJournalService =
+            balanceJournalService ?? BalanceJournalService(database: database)
+        self.dailyBalanceMaterializer =
+            dailyBalanceMaterializer ?? DailyBalanceMaterializer(database: database)
+    }
+
+    func saveCost(_ cost: OpexExpenseModel) async throws {
+        let savedCostId = try await database.saveOpexExpenseAsync(model: cost)
+        let savedCost = OpexExpenseModel(
+            id: savedCostId,
+            date: cost.date,
+            categoryId: cost.categoryId,
+            amount: cost.amount,
+            paymentAccount: cost.paymentAccount,
+            note: cost.note
+        )
+        let scopes = try await balanceJournalService.syncOpex(previous: nil, current: savedCost)
+        try await dailyBalanceMaterializer.materialize(scopes: scopes)
+    }
+
+    func updateCost(_ cost: OpexExpenseModel, date: Date, name: String, sum: Double) async throws {
+        let updatedCost = OpexExpenseModel(
+            id: cost.id,
+            date: date,
+            categoryId: cost.categoryId,
+            amount: sum,
+            paymentAccount: cost.paymentAccount,
+            note: name
+        )
+
+        try await database.updateOpexExpenseAsync(model: updatedCost)
+        let scopes = try await balanceJournalService.syncOpex(previous: cost, current: updatedCost)
+        try await dailyBalanceMaterializer.materialize(scopes: scopes)
+    }
+
+    func deleteCost(_ cost: OpexExpenseModel) async throws {
+        try await database.deleteOpexExpenseAsync(model: cost)
+        let scopes = try await balanceJournalService.syncOpex(previous: cost, current: nil)
+        try await dailyBalanceMaterializer.materialize(scopes: scopes)
+    }
+}
+
+extension FinancePersistenceProtocol {
+    func saveOrderAsync(order: OrderModel) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            saveOrder(order: order) { id in
+                if let id {
+                    continuation.resume(returning: id)
+                } else {
+                    continuation.resume(throwing: FinanceMutationError.saveFailed)
+                }
+            }
+        }
+    }
+
+    func updateOrderAsync(_ order: OrderModel) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            updateOrder(order) { success in
+                if success {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: FinanceMutationError.updateFailed)
+                }
+            }
+        }
+    }
+
+    func deleteOrderAsync(order: OrderModel) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteOrder(order: order) { success in
+                if success {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: FinanceMutationError.deleteFailed)
+                }
+            }
+        }
+    }
+
+    func saveOpexExpenseAsync(model: OpexExpenseModel) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            saveOpexExpense(model: model) { id in
+                if let id {
+                    continuation.resume(returning: id)
+                } else {
+                    continuation.resume(throwing: FinanceMutationError.saveFailed)
+                }
+            }
+        }
+    }
+
+    func updateOpexExpenseAsync(model: OpexExpenseModel) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            updateOpexExpense(model: model) { success in
+                if success {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: FinanceMutationError.updateFailed)
+                }
+            }
+        }
+    }
+
+    func deleteOpexExpenseAsync(model: OpexExpenseModel) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteOpexExpense(model: model) { success in
+                if success {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: FinanceMutationError.deleteFailed)
+                }
+            }
+        }
+    }
+
+    func saveJournalEntryAsync(_ model: JournalEntryModel) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            saveJournalEntry(model: model) { id in
+                if let id {
+                    continuation.resume(returning: id)
+                } else {
+                    continuation.resume(throwing: FinanceMutationError.saveFailed)
+                }
+            }
+        }
+    }
+
+    func fetchJournalEntriesAsync() async -> [JournalEntryModel] {
+        await withCheckedContinuation { continuation in
+            fetchJournalEntries { entries in
+                continuation.resume(returning: entries)
+            }
+        }
+    }
+
+    func saveDailyBalanceAsync(_ model: DailyBalanceModel) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            saveDailyBalance(model: model) { success in
+                if success {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: FinanceMutationError.saveFailed)
+                }
+            }
+        }
+    }
+
+    func fetchDailyBalancesAsync(
+        forAccount account: PaymentAccount,
+        from startDate: Date,
+        to endDate: Date
+    ) async -> [DailyBalanceModel] {
+        await withCheckedContinuation { continuation in
+            fetchDailyBalances(forAccount: account, from: startDate, to: endDate) { balances in
+                continuation.resume(returning: balances)
+            }
+        }
+    }
+
+    func deleteDocumentAsync(collection: String, documentId: String) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            delete(collection: collection, documentId: documentId) { success in
+                if success {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: FinanceMutationError.deleteFailed)
+                }
+            }
+        }
+    }
+}
+
+extension BinaryFloatingPoint {
+    fileprivate var isApproximatelyZero: Bool {
+        abs(self) < 0.000_1
+    }
 }

--- a/TrackMyCafe/Services/Domain/DomainDatabaseService.swift
+++ b/TrackMyCafe/Services/Domain/DomainDatabaseService.swift
@@ -277,24 +277,33 @@ class DomainDatabaseService: DomainDB {
         totalCost: Double,
         note: String?
     ) {
-        var updatedModel = FIROrderModel(dataModel: model)
-        updatedModel.date = date
-        updatedModel.type = type
-        updatedModel.sum = total
-        updatedModel.cash = cashAmount
-        updatedModel.card = cardAmount
-        updatedModel.totalCost = totalCost
-        updatedModel.note = note
+        let updatedOrder = OrderModel(
+            id: model.id,
+            date: date,
+            type: type,
+            sum: total,
+            cash: cashAmount,
+            card: cardAmount,
+            totalCost: totalCost,
+            note: note
+        )
+        updateOrder(updatedOrder) { _ in }
+    }
+
+    func updateOrder(_ order: OrderModel, completion: @escaping (Bool) -> Void) {
+        let updatedModel = FIROrderModel(dataModel: order)
         FirestoreDatabaseService.shared.update(
-            firModel: updatedModel, collection: FirebaseCollections.orders, documentId: model.id
+            firModel: updatedModel, collection: FirebaseCollections.orders, documentId: order.id
         ) { result in
             switch result {
             case .success():
                 self.logger.info("Order updated successfully in Firestore database")
+                completion(true)
             case .failure(let error):
                 self.logger.error(
                     "Failed to update order in Firestore database: \(error.localizedDescription)"
                 )
+                completion(false)
             }
         }
     }
@@ -704,6 +713,10 @@ class DomainDatabaseService: DomainDB {
     }
 
     func updateOpexExpense(model: OpexExpenseModel) {
+        updateOpexExpense(model: model) { _ in }
+    }
+
+    func updateOpexExpense(model: OpexExpenseModel, completion: @escaping (Bool) -> Void) {
         let firModel = FIROpexExpenseModel(dataModel: model)
         FirestoreDatabaseService.shared.update(
             firModel: firModel, collection: FirebaseCollections.opexExpenses,
@@ -712,8 +725,10 @@ class DomainDatabaseService: DomainDB {
             switch result {
             case .success():
                 self.logger.info("Opex expense updated successfully")
+                completion(true)
             case .failure(let error):
                 self.logger.error("Failed to update opex expense: \(error.localizedDescription)")
+                completion(false)
             }
         }
     }
@@ -830,7 +845,7 @@ class DomainDatabaseService: DomainDB {
                 completion(nil)
             }
         }
-        }
+    }
 
     func fetchDailyBalances(
         forAccount account: PaymentAccount,
@@ -856,8 +871,13 @@ class DomainDatabaseService: DomainDB {
             case .success(let firModels):
                 let balances =
                     firModels
-                    .filter { $0.date >= lowerBound && $0.date <= upperBound }
-                    .sorted { $0.date < $1.date }
+                    .map { DailyBalanceModel(firebaseModel: $0.1) }
+                    .filter { balance in
+                        balance.date >= lowerBound && balance.date <= upperBound
+                    }
+                    .sorted { lhs, rhs in
+                        lhs.date < rhs.date
+                    }
                 completion(balances)
             case .failure(let error):
                 completion([])

--- a/TrackMyCafe/View Layer/Flow/Costs/CostDetails/ViewModel/CostDetailsViewModel.swift
+++ b/TrackMyCafe/View Layer/Flow/Costs/CostDetails/ViewModel/CostDetailsViewModel.swift
@@ -45,6 +45,7 @@ class CostDetailsViewModel: CostDetailsViewModelType, Loggable {
             date: costDate,
             categoryId: cost.categoryId,
             amount: sum,
+            paymentAccount: cost.paymentAccount,
             note: name
         )
 
@@ -54,6 +55,7 @@ class CostDetailsViewModel: CostDetailsViewModelType, Loggable {
                 date: costDate,
                 categoryId: "General", // Default category for new items
                 amount: sum,
+                paymentAccount: cost.paymentAccount,
                 note: name
             )
             do {
@@ -64,8 +66,13 @@ class CostDetailsViewModel: CostDetailsViewModelType, Loggable {
                 throw error
             }
         } else {
-            await dataService.updateCost(updatedCost, date: costDate, name: name, sum: sum)
-            logger.notice("Cost \(updatedCost.id) updated successfully")
+            do {
+                try await dataService.updateCost(updatedCost, date: costDate, name: name, sum: sum)
+                logger.notice("Cost \(updatedCost.id) updated successfully")
+            } catch {
+                logger.error("Failed to update Cost \(updatedCost.id)")
+                throw error
+            }
         }
     }
 }

--- a/TrackMyCafe/View Layer/Flow/Costs/CostList/ViewModel/CostListViewModel.swift
+++ b/TrackMyCafe/View Layer/Flow/Costs/CostList/ViewModel/CostListViewModel.swift
@@ -10,6 +10,11 @@ import Foundation
 class CostListViewModel: CostListViewModelType, Loggable {
     private var selectedIndexPath: IndexPath?
     private var sectionsCosts: [(date: Date, items: [OpexExpenseModel])]?
+    private let dataService: CostDataServiceProtocol
+
+    init(dataService: CostDataServiceProtocol = DomainCostDataService()) {
+        self.dataService = dataService
+    }
     
     func getCosts(completion: @escaping () -> ()) {
         DomainDatabaseService.shared.fetchSectionsOfOpexExpenses { sectionsCosts in
@@ -51,7 +56,7 @@ class CostListViewModel: CostListViewModelType, Loggable {
               let sectionsCosts = self.sectionsCosts else { return nil }
         let cost = sectionsCosts[selectedIndexPath.section].items[selectedIndexPath.row]
         
-        return CostDetailsViewModel(cost: cost, dataService: DomainCostDataService())
+        return CostDetailsViewModel(cost: cost, dataService: dataService)
     }
     
     func selectRow(atIndexPath indexPath: IndexPath) {
@@ -66,12 +71,15 @@ class CostListViewModel: CostListViewModelType, Loggable {
     
     func deleteCostModel(atIndexPath indexPath: IndexPath) {
         guard let model = getCostModel(atIndexPath: indexPath) else { return }
-        
-        DomainDatabaseService.shared.deleteOpexExpense(model: model) { success in
-            if success {
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                try await dataService.deleteCost(model)
                 self.logger.notice("Costs \(model.id) deleted successfully")
-            } else {
-                self.logger.error("Failed to delete costs \(model.id)")
+            } catch {
+                self.logger.error("Failed to delete costs \(model.id): \(error.localizedDescription)")
             }
         }
     }

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/ViewModel/OrderDetailsViewModel.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/ViewModel/OrderDetailsViewModel.swift
@@ -13,6 +13,7 @@ class OrderDetailsViewModel: OrderDetailsViewModelType, Loggable {
     private var order: OrderModel
     private var types: [TypeModel] = []
     private var selectedRow: Int?
+    private let orderDataService: OrderDataServiceProtocol
     
     let productsViewModel: ProductListViewModel
     
@@ -31,9 +32,14 @@ class OrderDetailsViewModel: OrderDetailsViewModelType, Loggable {
     var isNewModel: Bool
     
     // MARK: - Init
-    init(model: OrderModel, isNewModel: Bool = false) {
+    init(
+        model: OrderModel,
+        isNewModel: Bool = false,
+        orderDataService: OrderDataServiceProtocol = DomainOrderDataService()
+    ) {
         self.order = model
         self.isNewModel = isNewModel
+        self.orderDataService = orderDataService
         self.productsViewModel = ProductListViewModel()
         
         fetchTypes()
@@ -136,39 +142,54 @@ class OrderDetailsViewModel: OrderDetailsViewModelType, Loggable {
             totalCost: totalCost,
             note: note
         )
-        
-        DomainDatabaseService.shared.saveOrder(order: newOrder) { [weak self] documentId in
-            guard let documentId = documentId else {
+
+        Task { [weak self] in
+            guard let self else {
                 completion(false)
                 return
             }
-            self?.order.id = documentId
-            self?.isNewModel = false
-            completion(true)
+
+            do {
+                let savedOrder = try await orderDataService.createOrder(newOrder)
+                self.order = savedOrder
+                self.isNewModel = false
+                completion(true)
+            } catch {
+                self.logger.error("Failed to create order \(newOrder.id): \(error.localizedDescription)")
+                completion(false)
+            }
         }
     }
     
     private func updateOrder(date: Date, type: String, cash: Double, card: Double, note: String?, completion: @escaping (Bool) -> Void) {
         let sum = productsViewModel.getTotalAmount()
         let totalCost = productsViewModel.getTotalCostAmount()
-        
-        DomainDatabaseService.shared.fetchOrders(forId: id) { fetchedOrder in
-            guard let fetchedOrder = fetchedOrder else {
+
+        let updatedOrder = OrderModel(
+            id: order.id,
+            date: date,
+            type: type,
+            sum: sum,
+            cash: cash,
+            card: card,
+            totalCost: totalCost,
+            note: note
+        )
+
+        Task { [weak self] in
+            guard let self else {
                 completion(false)
                 return
             }
-            
-            DomainDatabaseService.shared.updateOrders(
-                model: fetchedOrder,
-                date: date,
-                type: type,
-                total: sum,
-                cashAmount: cash,
-                cardAmount: card,
-                totalCost: totalCost,
-                note: note
-            )
-            completion(true)
+
+            do {
+                try await orderDataService.updateOrder(previous: order, current: updatedOrder)
+                self.order = updatedOrder
+                completion(true)
+            } catch {
+                self.logger.error("Failed to update order \(updatedOrder.id): \(error.localizedDescription)")
+                completion(false)
+            }
         }
     }
     
@@ -212,10 +233,20 @@ class OrderDetailsViewModel: OrderDetailsViewModelType, Loggable {
     
     func deleteOrder(completion: @escaping () -> Void) {
         ProductListViewModel.deleteOrder(withOrderId: id, date: date)
-        DomainDatabaseService.shared.deleteOrder(order: order) { success in
-            if success {
-                self.logger.notice("Order deleted")
+
+        Task { [weak self] in
+            guard let self else {
+                completion()
+                return
             }
+
+            do {
+                try await orderDataService.deleteOrder(order)
+                self.logger.notice("Order deleted")
+            } catch {
+                self.logger.error("Failed to delete order \(self.order.id): \(error.localizedDescription)")
+            }
+
             completion()
         }
     }

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderList/ViewModel/OrderListViewModel.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderList/ViewModel/OrderListViewModel.swift
@@ -11,6 +11,11 @@ class OrderListViewModel: OrderListViewModelType, Loggable {
     
     private var selectedIndexPath: IndexPath?
     private var sectionsOrders: [(date: Date, items: [OrderModel])]?
+    private let orderDataService: OrderDataServiceProtocol
+
+    init(orderDataService: OrderDataServiceProtocol = DomainOrderDataService()) {
+        self.orderDataService = orderDataService
+    }
     
     func getOrders(completion: @escaping () -> Void) {
         DomainDatabaseService.shared.fetchSectionsOfOrders { [weak self] sectionsOrders in
@@ -66,12 +71,15 @@ class OrderListViewModel: OrderListViewModelType, Loggable {
     func deleteOrderModel(atIndexPath indexPath: IndexPath) {
         guard let model = getOrder(atIndexPath: indexPath) else { return }
         ProductListViewModel.deleteOrder(withOrderId: model.id, date: model.date)
-        
-        DomainDatabaseService.shared.deleteOrder(order: model) { success in
-            if success {
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                try await orderDataService.deleteOrder(model)
                 self.logger.notice("Order \(model.id) deleted successfully")
-            } else {
-                self.logger.error("Failed to delete order \(model.id)")
+            } catch {
+                self.logger.error("Failed to delete order \(model.id): \(error.localizedDescription)")
             }
         }
     }


### PR DESCRIPTION
## Title

- Use Conventional Commits: `feat(finance): implement journal engine and daily balance materialization`

## Plan

- Add finance service layer for journal append/storno and daily balance materialization.
- Wire order and opex mutations to the new services.
- Keep Firestore as source of truth and avoid new Realm sync infrastructure.

## Code

- Added finance-specific service layer in `DomainCostDataService.swift`:
  - `BalanceJournalService`
  - `DailyBalanceMaterializer`
  - `DomainOrderDataService`
  - async persistence helpers through a shared protocol-driven path
- Wired order create/update/delete in:
  - `OrderDetailsViewModel.swift`
  - `OrderListViewModel.swift`
- Wired opex create/update/delete in:
  - `CostDetailsViewModel.swift`
  - `CostListViewModel.swift`
- Updated `DomainDatabaseService.swift` to support deterministic async order/opex updates and daily balance fetching for materialization.
- Preserved legacy opex behavior: entries without `paymentAccount` do not affect journal or balances.

## Expected outcome

- Order create appends cash/card journal entries and updates daily balances.
- Order update appends storno for the previous state, appends new entries, and rematerializes affected balances.
- Order delete appends reversal/storno entries and removes its net effect from balances.
- Opex create/update/delete works through finance services when `paymentAccount` is present.
- No Home/reporting UI changes are included.

## Validation

- Checked diagnostics for edited Swift files: clean.
- Performed targeted code-level validation of mutation flows and affected Firestore collections.
- Full `xcodebuild` execution in the agent environment was blocked by sandbox package-resolution restrictions, so simulator/runtime verification should be completed locally in Xcode.
- UI note: please run the iOS Simulator in Xcode to visually verify any UI changes.

## References

- Closes #212
- Closes #213