### PR TITLE
feat(finance): add history backfill rollout hardening

### DIFF
--- a/TrackMyCafe.xcodeproj/project.pbxproj
+++ b/TrackMyCafe.xcodeproj/project.pbxproj
@@ -283,6 +283,9 @@
 		F36217CD2EC04E5300965886 /* DomainProductPriceDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36217CC2EC04E5300965886 /* DomainProductPriceDataService.swift */; };
 		F36217CE2EC04E5300965886 /* DomainProductPriceDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36217CC2EC04E5300965886 /* DomainProductPriceDataService.swift */; };
 		F36217CF2EC04E5300965886 /* DomainProductPriceDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36217CC2EC04E5300965886 /* DomainProductPriceDataService.swift */; };
+		F363F28A2FED4E2D00910F20 /* FinanceHistoryBackfillService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F2892FED4E2D00910F20 /* FinanceHistoryBackfillService.swift */; };
+		F363F28B2FED4E2D00910F20 /* FinanceHistoryBackfillService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F2892FED4E2D00910F20 /* FinanceHistoryBackfillService.swift */; };
+		F363F28C2FED4E2D00910F20 /* FinanceHistoryBackfillService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F2892FED4E2D00910F20 /* FinanceHistoryBackfillService.swift */; };
 		F36DA6AB2F3B57C000CE345C /* IngredientTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36DA6AA2F3B57C000CE345C /* IngredientTableViewCell.swift */; };
 		F36DA6AC2F3B57C000CE345C /* IngredientTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36DA6AA2F3B57C000CE345C /* IngredientTableViewCell.swift */; };
 		F36DA6AD2F3B57C000CE345C /* IngredientTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36DA6AA2F3B57C000CE345C /* IngredientTableViewCell.swift */; };
@@ -913,6 +916,7 @@
 		F36217C42EC04E2300965886 /* ProductDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsViewModel.swift; sourceTree = "<group>"; };
 		F36217C52EC04E2300965886 /* ProductDetailsViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsViewModelType.swift; sourceTree = "<group>"; };
 		F36217CC2EC04E5300965886 /* DomainProductPriceDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainProductPriceDataService.swift; sourceTree = "<group>"; };
+		F363F2892FED4E2D00910F20 /* FinanceHistoryBackfillService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinanceHistoryBackfillService.swift; sourceTree = "<group>"; };
 		F36DA6AA2F3B57C000CE345C /* IngredientTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngredientTableViewCell.swift; sourceTree = "<group>"; };
 		F371AA7727589CFB0059710A /* SettingsDataTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDataTableViewCell.swift; sourceTree = "<group>"; };
 		F371AA7A2758B0890059710A /* UIViewController+AlertLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+AlertLanguage.swift"; sourceTree = "<group>"; };
@@ -2285,6 +2289,7 @@
 		F3E357E72BEFA203005050CB /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				F363F2892FED4E2D00910F20 /* FinanceHistoryBackfillService.swift */,
 				F371BEDD2FED42B800D72C3A /* DomainManualMovementService.swift */,
 				F3F205522FD831A0007249FB /* DomainProductCategoryDataService.swift */,
 				F32B52B62F2B6F3D0005E63D /* DomainIngredientDataService.swift */,
@@ -3045,6 +3050,7 @@
 				F3988ADC27EB111600215976 /* CostListViewModelType.swift in Sources */,
 				F3410E9E2BDD3A5A0007157B /* SVProgressHUD+Extension.swift in Sources */,
 				F3EAAD00275266EA004B9AF6 /* ProductDetailsViewController.swift in Sources */,
+				F363F28A2FED4E2D00910F20 /* FinanceHistoryBackfillService.swift in Sources */,
 				F3EB27D927F30EBE00BB2D93 /* ProductListViewModelType.swift in Sources */,
 				F385B4062C1D784300973CAA /* PersonTableViewCell.swift in Sources */,
 				F3F6A6052C2FEB9A000961C8 /* IAPManager.swift in Sources */,
@@ -3268,6 +3274,7 @@
 				F3B339D82C0B22FE0073F19A /* ProductDetailsViewController.swift in Sources */,
 				F3B339D92C0B22FE0073F19A /* ProductListViewModelType.swift in Sources */,
 				F3B339DA2C0B22FE0073F19A /* SignInController.swift in Sources */,
+				F363F28C2FED4E2D00910F20 /* FinanceHistoryBackfillService.swift in Sources */,
 				F3B339DB2C0B22FE0073F19A /* Bundle+Extension.swift in Sources */,
 				F3B339DC2C0B22FE0073F19A /* ProductPriceTableViewCell.swift in Sources */,
 				F3B339DD2C0B22FE0073F19A /* R.generated.swift in Sources */,
@@ -3491,6 +3498,7 @@
 				F3B33A772C0B23450073F19A /* ProductDetailsViewController.swift in Sources */,
 				F3B33A782C0B23450073F19A /* ProductListViewModelType.swift in Sources */,
 				F3B33A792C0B23450073F19A /* SignInController.swift in Sources */,
+				F363F28B2FED4E2D00910F20 /* FinanceHistoryBackfillService.swift in Sources */,
 				F3B33A7A2C0B23450073F19A /* Bundle+Extension.swift in Sources */,
 				F3B33A7B2C0B23450073F19A /* ProductPriceTableViewCell.swift in Sources */,
 				F3B33A7C2C0B23450073F19A /* R.generated.swift in Sources */,

--- a/TrackMyCafe/Application/SceneDelegate.swift
+++ b/TrackMyCafe/Application/SceneDelegate.swift
@@ -157,6 +157,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, Loggable {
         } else {
             // Якщо сесія дійсна, переходимо на головний екран додатку
             window?.rootViewController = MainTabBarController()
+            runFinanceHistoryBackfillIfNeeded()
         }
     }
 
@@ -164,6 +165,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, Loggable {
         let overlayView = UIScreen.main.snapshotView(afterScreenUpdates: false)
         controller.view.addSubview(overlayView)
         window?.rootViewController = controller
+        runFinanceHistoryBackfillIfNeeded(for: controller)
 
         UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCrossDissolve, animations: {
             overlayView.alpha = 0
@@ -248,6 +250,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, Loggable {
         logMessage += "===========================================\n"
 
         logger.info(logMessage)
+    }
+
+    private func runFinanceHistoryBackfillIfNeeded(for controller: UIViewController? = nil) {
+        let rootController = controller ?? window?.rootViewController
+        guard Auth.auth().currentUser != nil else { return }
+        guard rootController is MainTabBarController else { return }
+
+        Task {
+            do {
+                _ = try await FinanceHistoryBackfillService().runIfNeeded()
+            } catch {
+                logger.error("Finance history backfill failed: \(error.localizedDescription)")
+            }
+        }
     }
 }
 

--- a/TrackMyCafe/Data Layer/Utils/Constants.swift
+++ b/TrackMyCafe/Data Layer/Utils/Constants.swift
@@ -132,6 +132,8 @@ struct UserDefaultsKeys {
     static let hasSeenInitialPaywall = "hasSeenInitialPaywall"
     static let hasRunBefore = "hasRunBefore"
     static let pendingSubscriptionSync = "pendingSubscriptionSync"
+    static let financeHistoryBackfillCompleted = "finance.historyBackfillCompleted"
+    static let financeHistoryBackfillCompletedAt = "finance.historyBackfillCompletedAt"
 }
 
 enum OrderEntryMode: String {

--- a/TrackMyCafe/Services/Domain/FinanceHistoryBackfillService.swift
+++ b/TrackMyCafe/Services/Domain/FinanceHistoryBackfillService.swift
@@ -1,0 +1,266 @@
+import Foundation
+
+protocol FinanceHistorySourceFetching {
+    func fetchOrders(completion: @escaping ([OrderModel]) -> Void)
+    func fetchOpexExpenses(completion: @escaping ([OpexExpenseModel]) -> Void)
+    func fetchPurchases(completion: @escaping ([PurchaseModel]) -> Void)
+}
+
+extension DomainDatabaseService: FinanceHistorySourceFetching {}
+
+final class FinanceHistoryBackfillService: Loggable {
+    private let sourceFetcher: FinanceHistorySourceFetching
+    private let persistence: FinancePersistenceProtocol
+    private let dailyBalanceMaterializer: DailyBalanceMaterializerProtocol
+    private let userDefaults: UserDefaults
+    private let calendar: Calendar
+
+    init(
+        sourceFetcher: FinanceHistorySourceFetching = DomainDatabaseService.shared,
+        persistence: FinancePersistenceProtocol = DomainDatabaseService.shared,
+        dailyBalanceMaterializer: DailyBalanceMaterializerProtocol? = nil,
+        userDefaults: UserDefaults = .standard,
+        calendar: Calendar = .current
+    ) {
+        self.sourceFetcher = sourceFetcher
+        self.persistence = persistence
+        self.dailyBalanceMaterializer =
+            dailyBalanceMaterializer ?? DailyBalanceMaterializer(database: persistence)
+        self.userDefaults = userDefaults
+        self.calendar = calendar
+    }
+
+    @discardableResult
+    func runIfNeeded() async throws -> Bool {
+        guard !userDefaults.bool(forKey: UserDefaultsKeys.financeHistoryBackfillCompleted) else {
+            logger.info("Finance history backfill already completed, skipping")
+            return false
+        }
+
+        let plan = await makePlan()
+
+        for expectedEntry in plan.missingEntries {
+            _ = try await persistence.saveJournalEntryAsync(expectedEntry.entry)
+        }
+
+        try await dailyBalanceMaterializer.materialize(scopes: plan.materializationScopes)
+
+        userDefaults.set(true, forKey: UserDefaultsKeys.financeHistoryBackfillCompleted)
+        userDefaults.set(Date(), forKey: UserDefaultsKeys.financeHistoryBackfillCompletedAt)
+
+        logger.info(
+            "Finance history backfill completed. Created \(plan.missingEntries.count) entries, rematerialized \(plan.materializationScopes.count) scope(s)"
+        )
+
+        return true
+    }
+
+    private func makePlan() async -> FinanceHistoryBackfillPlan {
+        async let orders = sourceFetcher.fetchOrdersAsync()
+        async let expenses = sourceFetcher.fetchOpexExpensesAsync()
+        async let purchases = sourceFetcher.fetchPurchasesAsync()
+        async let existingEntries = persistence.fetchJournalEntriesAsync()
+
+        let expectedEntries =
+            makeExpectedEntries(
+                orders: await orders,
+                expenses: await expenses,
+                purchases: await purchases
+            )
+        let existingKeys = Set(
+            await existingEntries
+                .filter { $0.sourceType != .manual }
+                .map { FinanceExpectedJournalEntry.MatchKey(entry: $0, calendar: calendar) }
+        )
+        let missingEntries = expectedEntries.filter { !existingKeys.contains($0.matchKey) }
+        let materializationScopes = makeMaterializationScopes(from: expectedEntries)
+
+        return FinanceHistoryBackfillPlan(
+            missingEntries: missingEntries,
+            materializationScopes: materializationScopes
+        )
+    }
+
+    private func makeExpectedEntries(
+        orders: [OrderModel],
+        expenses: [OpexExpenseModel],
+        purchases: [PurchaseModel]
+    ) -> [FinanceExpectedJournalEntry] {
+        let orderEntries = orders.flatMap { order -> [FinanceExpectedJournalEntry] in
+            var entries: [FinanceExpectedJournalEntry] = []
+
+            if !order.cash.isEffectivelyZero {
+                entries.append(
+                    makeExpectedEntry(
+                        id: makeDocumentId(sourceType: .order, sourceId: order.id, account: .cash),
+                        date: order.date,
+                        account: .cash,
+                        amount: order.cash,
+                        sourceType: .order,
+                        sourceId: order.id,
+                        note: order.note
+                    )
+                )
+            }
+
+            if !order.card.isEffectivelyZero {
+                entries.append(
+                    makeExpectedEntry(
+                        id: makeDocumentId(sourceType: .order, sourceId: order.id, account: .card),
+                        date: order.date,
+                        account: .card,
+                        amount: order.card,
+                        sourceType: .order,
+                        sourceId: order.id,
+                        note: order.note
+                    )
+                )
+            }
+
+            return entries
+        }
+
+        let expenseEntries = expenses.compactMap { expense -> FinanceExpectedJournalEntry? in
+            guard
+                let account = expense.paymentAccount,
+                !expense.amount.isEffectivelyZero
+            else {
+                return nil
+            }
+
+            return makeExpectedEntry(
+                id: makeDocumentId(sourceType: .opex, sourceId: expense.id, account: account),
+                date: expense.date,
+                account: account,
+                amount: -expense.amount,
+                sourceType: .opex,
+                sourceId: expense.id,
+                note: expense.note
+            )
+        }
+
+        let purchaseEntries = purchases.compactMap { purchase -> FinanceExpectedJournalEntry? in
+            guard
+                let account = purchase.paymentAccount,
+                !purchase.totalAmount.isEffectivelyZero
+            else {
+                return nil
+            }
+
+            return makeExpectedEntry(
+                id: makeDocumentId(sourceType: .purchase, sourceId: purchase.id, account: account),
+                date: purchase.date,
+                account: account,
+                amount: -purchase.totalAmount,
+                sourceType: .purchase,
+                sourceId: purchase.id,
+                note: nil
+            )
+        }
+
+        return orderEntries + expenseEntries + purchaseEntries
+    }
+
+    private func makeExpectedEntry(
+        id: String,
+        date: Date,
+        account: PaymentAccount,
+        amount: Double,
+        sourceType: JournalSourceType,
+        sourceId: String,
+        note: String?
+    ) -> FinanceExpectedJournalEntry {
+        FinanceExpectedJournalEntry(
+            entry: JournalEntryModel(
+                id: id,
+                date: date,
+                account: account,
+                amount: amount,
+                sourceType: sourceType,
+                sourceId: sourceId,
+                note: note
+            ),
+            calendar: calendar
+        )
+    }
+
+    private func makeMaterializationScopes(
+        from expectedEntries: [FinanceExpectedJournalEntry]
+    ) -> Set<BalanceScope> {
+        let earliestDateByAccount = Dictionary(grouping: expectedEntries, by: \.entry.account)
+            .compactMapValues { entries in
+                entries.map { calendar.startOfDay(for: $0.entry.date) }.min()
+            }
+
+        return Set(
+            earliestDateByAccount.map { account, date in
+                BalanceScope(account: account, date: date)
+            }
+        )
+    }
+
+    private func makeDocumentId(
+        sourceType: JournalSourceType,
+        sourceId: String,
+        account: PaymentAccount
+    ) -> String {
+        "backfill_\(sourceType.rawValue)_\(account.rawValue)_\(sourceId)"
+    }
+}
+
+private struct FinanceHistoryBackfillPlan {
+    let missingEntries: [FinanceExpectedJournalEntry]
+    let materializationScopes: Set<BalanceScope>
+}
+
+private struct FinanceExpectedJournalEntry {
+    let entry: JournalEntryModel
+    let matchKey: MatchKey
+
+    init(entry: JournalEntryModel, calendar: Calendar) {
+        self.entry = entry
+        self.matchKey = MatchKey(entry: entry, calendar: calendar)
+    }
+
+    struct MatchKey: Hashable {
+        let sourceType: JournalSourceType
+        let sourceId: String
+        let account: PaymentAccount
+        let normalizedDate: Date
+        let amountInMinorUnits: Int64
+
+        init(entry: JournalEntryModel, calendar: Calendar = .current) {
+            self.sourceType = entry.sourceType
+            self.sourceId = entry.sourceId
+            self.account = entry.account
+            self.normalizedDate = calendar.startOfDay(for: entry.date)
+            self.amountInMinorUnits = Int64((entry.amount * 100).rounded())
+        }
+    }
+}
+
+extension BinaryFloatingPoint {
+    fileprivate var isEffectivelyZero: Bool {
+        abs(self) < 0.000_1
+    }
+}
+
+extension FinanceHistorySourceFetching {
+    fileprivate func fetchOrdersAsync() async -> [OrderModel] {
+        await withCheckedContinuation { continuation in
+            fetchOrders { continuation.resume(returning: $0) }
+        }
+    }
+
+    fileprivate func fetchOpexExpensesAsync() async -> [OpexExpenseModel] {
+        await withCheckedContinuation { continuation in
+            fetchOpexExpenses { continuation.resume(returning: $0) }
+        }
+    }
+
+    fileprivate func fetchPurchasesAsync() async -> [PurchaseModel] {
+        await withCheckedContinuation { continuation in
+            fetchPurchases { continuation.resume(returning: $0) }
+        }
+    }
+}

--- a/TrackMyCafeTests/TrackMyCafeTests.swift
+++ b/TrackMyCafeTests/TrackMyCafeTests.swift
@@ -272,6 +272,158 @@ final class TrackMyCafeTests: XCTestCase {
         XCTAssertEqual(materializer.receivedScopes, expectedScopes)
     }
 
+    func testFinanceHistoryBackfillService_createsOnlyMissingEntriesAndMarksCompleted()
+        async throws
+    {
+        let sourceFetcher = MockFinanceHistorySourceFetcher()
+        let persistence = MockFinancePersistence()
+        let materializer = MockDailyBalanceMaterializer()
+        let defaults = makeUserDefaultsSuite()
+
+        let dayOne = makeDate(year: 2026, month: 6, day: 20)
+        let dayTwo = makeDate(year: 2026, month: 6, day: 21)
+        let dayThree = makeDate(year: 2026, month: 6, day: 22)
+
+        sourceFetcher.orders = [
+            OrderModel(
+                id: "order-1",
+                date: dayOne,
+                type: "Hall",
+                sum: 150,
+                cash: 100,
+                card: 50,
+                totalCost: 60,
+                note: "Order"
+            )
+        ]
+        sourceFetcher.expenses = [
+            OpexExpenseModel(
+                id: "opex-1",
+                date: dayTwo,
+                categoryId: "General",
+                amount: 25,
+                paymentAccount: .cash,
+                note: "Beans"
+            ),
+            OpexExpenseModel(
+                id: "opex-legacy",
+                date: dayThree,
+                categoryId: "General",
+                amount: 11,
+                paymentAccount: nil,
+                note: "Legacy"
+            ),
+        ]
+        sourceFetcher.purchases = [
+            PurchaseModel(
+                id: "purchase-1",
+                date: dayThree,
+                ingredientId: "ingredient-1",
+                quantity: 2,
+                price: 20,
+                totalAmount: 40,
+                paymentAccount: .card
+            ),
+            PurchaseModel(
+                id: "purchase-legacy",
+                date: dayThree,
+                ingredientId: "ingredient-2",
+                quantity: 1,
+                price: 15,
+                totalAmount: 15,
+                paymentAccount: nil
+            ),
+        ]
+
+        persistence.journalEntries = [
+            JournalEntryModel(
+                date: dayOne,
+                account: .cash,
+                amount: 100,
+                sourceType: .order,
+                sourceId: "order-1",
+                note: "Old note"
+            )
+        ]
+
+        let service = FinanceHistoryBackfillService(
+            sourceFetcher: sourceFetcher,
+            persistence: persistence,
+            dailyBalanceMaterializer: materializer,
+            userDefaults: defaults
+        )
+
+        let didRun = try await service.runIfNeeded()
+
+        XCTAssertTrue(didRun)
+        XCTAssertEqual(
+            Set(persistence.savedJournalEntries.map { JournalEntrySnapshot(entry: $0) }),
+            Set([
+                JournalEntrySnapshot(account: .card, amount: 50),
+                JournalEntrySnapshot(account: .cash, amount: -25),
+                JournalEntrySnapshot(account: .card, amount: -40),
+            ])
+        )
+        XCTAssertEqual(
+            materializer.receivedScopes,
+            Set([
+                BalanceScope(account: .cash, date: dayOne),
+                BalanceScope(account: .card, date: dayOne),
+            ])
+        )
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultsKeys.financeHistoryBackfillCompleted))
+        XCTAssertNotNil(defaults.object(forKey: UserDefaultsKeys.financeHistoryBackfillCompletedAt))
+    }
+
+    func testFinanceHistoryBackfillService_existingEntriesDoNotDuplicateAndStillMaterialize()
+        async throws
+    {
+        let sourceFetcher = MockFinanceHistorySourceFetcher()
+        let persistence = MockFinancePersistence()
+        let materializer = MockDailyBalanceMaterializer()
+        let defaults = makeUserDefaultsSuite()
+        let date = makeDate(year: 2026, month: 6, day: 22)
+
+        sourceFetcher.orders = [
+            OrderModel(
+                id: "order-existing",
+                date: date,
+                type: "Hall",
+                sum: 80,
+                cash: 80,
+                card: 0,
+                totalCost: 25,
+                note: "Current"
+            )
+        ]
+        persistence.journalEntries = [
+            JournalEntryModel(
+                date: date,
+                account: .cash,
+                amount: 80,
+                sourceType: .order,
+                sourceId: "order-existing",
+                note: "Previous note"
+            )
+        ]
+
+        let service = FinanceHistoryBackfillService(
+            sourceFetcher: sourceFetcher,
+            persistence: persistence,
+            dailyBalanceMaterializer: materializer,
+            userDefaults: defaults
+        )
+
+        let didRun = try await service.runIfNeeded()
+
+        XCTAssertTrue(didRun)
+        XCTAssertTrue(persistence.savedJournalEntries.isEmpty)
+        XCTAssertEqual(
+            materializer.receivedScopes,
+            [BalanceScope(account: .cash, date: date)]
+        )
+    }
+
     private func makeDate(year: Int, month: Int, day: Int) -> Date {
         var components = DateComponents()
         components.year = year
@@ -279,6 +431,13 @@ final class TrackMyCafeTests: XCTestCase {
         components.day = day
         components.hour = 12
         return Calendar.current.date(from: components) ?? Date()
+    }
+
+    private func makeUserDefaultsSuite() -> UserDefaults {
+        let suiteName = "TrackMyCafeTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
     }
 }
 
@@ -399,5 +558,23 @@ private final class MockDailyBalanceMaterializer: DailyBalanceMaterializerProtoc
 
     func materialize(scopes: Set<BalanceScope>) async throws {
         receivedScopes = scopes
+    }
+}
+
+private final class MockFinanceHistorySourceFetcher: FinanceHistorySourceFetching {
+    var orders: [OrderModel] = []
+    var expenses: [OpexExpenseModel] = []
+    var purchases: [PurchaseModel] = []
+
+    func fetchOrders(completion: @escaping ([OrderModel]) -> Void) {
+        completion(orders)
+    }
+
+    func fetchOpexExpenses(completion: @escaping ([OpexExpenseModel]) -> Void) {
+        completion(expenses)
+    }
+
+    func fetchPurchases(completion: @escaping ([PurchaseModel]) -> Void) {
+        completion(purchases)
     }
 }


### PR DESCRIPTION
## Summary

This PR finishes the PR4 part of the finance migration by backfilling historical balance-affecting data into `journal_entries` and re-materializing `daily_balances`.

Scope of this PR:
- existing `orders`
- existing `opexExpenses`
- existing `purchases` with `paymentAccount`
- rollout-safe startup execution
- tests for the backfill behavior

This is a stacked PR on top of `feat/147-pr3-home-ui-daily-balance`.

## What changed

- Added `FinanceHistoryBackfillService` to derive missing journal history from existing finance data.
- Backfill creates entries only for balance-affecting history:
  - `orders`
  - `opexExpenses` with `paymentAccount`
  - `purchases` with `paymentAccount`
- Legacy `opexExpenses` and `purchases` without `paymentAccount` are intentionally ignored for balance reconstruction.
- Added rollout markers in `UserDefaults` so the migration runs only once per installed app state.
- Triggered backfill from app startup only after the authenticated user reaches `MainTabBarController`.
- Added focused tests for:
  - creating only missing historical entries
  - idempotent reruns
  - rollout completion persistence
- Updated the Xcode project to include the new service file in targets.

## Why this approach

The app already uses journal-based balance updates for new mutations. The missing part was historical data for users who already had orders/opex/purchases before the journal flow existed.

This implementation keeps `journal_entries` / `daily_balances` as the only balance source of truth and avoids introducing any parallel migration model.

The backfill is intentionally conservative:
- it does not touch `.manual` journal records
- it does not synthesize balance effects for legacy records that do not contain payment-account information
- it only inserts missing expected history instead of blindly replaying everything every launch

## Files of interest

- `TrackMyCafe/Services/Domain/FinanceHistoryBackfillService.swift`
- `TrackMyCafe/Application/SceneDelegate.swift`
- `TrackMyCafe/Data Layer/Utils/Constants.swift`
- `TrackMyCafeTests/TrackMyCafeTests.swift`

## Validation

What was verified in this environment:
- IDE diagnostics are clean for the changed Swift files.
- Diff against `feat/147-pr3-home-ui-daily-balance` matches the intended PR4 scope.
- Focused unit tests for the new backfill service were added.

What could not be fully verified here:
- Full Xcode build/test run, because package resolution fails in the sandbox with `sandbox-exec: sandbox_apply: Operation not permitted`.

## Remaining manual QA

Please verify in Xcode / Simulator with historical data:
- first launch after rollout on an account with existing orders/opex/purchases
- historical edit scenarios for old orders/opex/purchases
- delete flows after backfill
- interaction with manual movements
- dashboard balances after backfill completes

## References

- Refs #215
- Refs #216