### PR TITLE
fix(ui): standardize table view lists and restore purchase deletion

### DIFF
--- a/TrackMyCafe.xcodeproj/project.pbxproj
+++ b/TrackMyCafe.xcodeproj/project.pbxproj
@@ -286,6 +286,9 @@
 		F363F28A2FED4E2D00910F20 /* FinanceHistoryBackfillService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F2892FED4E2D00910F20 /* FinanceHistoryBackfillService.swift */; };
 		F363F28B2FED4E2D00910F20 /* FinanceHistoryBackfillService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F2892FED4E2D00910F20 /* FinanceHistoryBackfillService.swift */; };
 		F363F28C2FED4E2D00910F20 /* FinanceHistoryBackfillService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F2892FED4E2D00910F20 /* FinanceHistoryBackfillService.swift */; };
+		F363F28E2FEE7C1800910F20 /* UITableView+StandardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F28D2FEE7C1800910F20 /* UITableView+StandardList.swift */; };
+		F363F28F2FEE7C1800910F20 /* UITableView+StandardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F28D2FEE7C1800910F20 /* UITableView+StandardList.swift */; };
+		F363F2902FEE7C1800910F20 /* UITableView+StandardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F28D2FEE7C1800910F20 /* UITableView+StandardList.swift */; };
 		F36DA6AB2F3B57C000CE345C /* IngredientTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36DA6AA2F3B57C000CE345C /* IngredientTableViewCell.swift */; };
 		F36DA6AC2F3B57C000CE345C /* IngredientTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36DA6AA2F3B57C000CE345C /* IngredientTableViewCell.swift */; };
 		F36DA6AD2F3B57C000CE345C /* IngredientTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36DA6AA2F3B57C000CE345C /* IngredientTableViewCell.swift */; };
@@ -917,6 +920,7 @@
 		F36217C52EC04E2300965886 /* ProductDetailsViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsViewModelType.swift; sourceTree = "<group>"; };
 		F36217CC2EC04E5300965886 /* DomainProductPriceDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainProductPriceDataService.swift; sourceTree = "<group>"; };
 		F363F2892FED4E2D00910F20 /* FinanceHistoryBackfillService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinanceHistoryBackfillService.swift; sourceTree = "<group>"; };
+		F363F28D2FEE7C1800910F20 /* UITableView+StandardList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+StandardList.swift"; sourceTree = "<group>"; };
 		F36DA6AA2F3B57C000CE345C /* IngredientTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngredientTableViewCell.swift; sourceTree = "<group>"; };
 		F371AA7727589CFB0059710A /* SettingsDataTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDataTableViewCell.swift; sourceTree = "<group>"; };
 		F371AA7A2758B0890059710A /* UIViewController+AlertLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+AlertLanguage.swift"; sourceTree = "<group>"; };
@@ -1417,6 +1421,7 @@
 		F316A2F7273804AB0083E830 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				F363F28D2FEE7C1800910F20 /* UITableView+StandardList.swift */,
 				F371AA7A2758B0890059710A /* UIViewController+AlertLanguage.swift */,
 				F3DB41B82EBDE2270095FBE1 /* UITextField+NumericInput.swift */,
 				F385B4142C1D863D00973CAA /* BaseReusableView.swift */,
@@ -3063,6 +3068,7 @@
 				F32F83902FE935AE00F4B4AE /* PaymentAccount.swift in Sources */,
 				F32F83912FE935AE00F4B4AE /* JournalEntryModel.swift in Sources */,
 				F3410E6F2BDD25DE0007157B /* R.generated.swift in Sources */,
+				F363F2902FEE7C1800910F20 /* UITableView+StandardList.swift in Sources */,
 				F3410EAA2BDD3E230007157B /* MainNavigationController.swift in Sources */,
 				F3410E8B2BDD2D610007157B /* Theme.swift in Sources */,
 				F34BC9C52F63455E000476B5 /* BaseListTableViewCell.swift in Sources */,
@@ -3287,6 +3293,7 @@
 				F32F83982FE935AE00F4B4AE /* PaymentAccount.swift in Sources */,
 				F32F83992FE935AE00F4B4AE /* JournalEntryModel.swift in Sources */,
 				F39D78592C2034EB0003B556 /* BaseDatabaseModel.swift in Sources */,
+				F363F28E2FEE7C1800910F20 /* UITableView+StandardList.swift in Sources */,
 				F3B339E22C0B22FE0073F19A /* ProductListViewController.swift in Sources */,
 				F3F6A6312C327A48000961C8 /* UITableView+Reusable.swift in Sources */,
 				F34BC9C32F63455E000476B5 /* BaseListTableViewCell.swift in Sources */,
@@ -3511,6 +3518,7 @@
 				F32F83942FE935AE00F4B4AE /* PaymentAccount.swift in Sources */,
 				F32F83952FE935AE00F4B4AE /* JournalEntryModel.swift in Sources */,
 				F39D785A2C2034EC0003B556 /* BaseDatabaseModel.swift in Sources */,
+				F363F28F2FEE7C1800910F20 /* UITableView+StandardList.swift in Sources */,
 				F3B33A812C0B23450073F19A /* ProductListViewController.swift in Sources */,
 				F3F6A6322C327A48000961C8 /* UITableView+Reusable.swift in Sources */,
 				F34BC9C72F63455E000476B5 /* BaseListTableViewCell.swift in Sources */,

--- a/TrackMyCafe/Extensions/UI/UITableView+StandardList.swift
+++ b/TrackMyCafe/Extensions/UI/UITableView+StandardList.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+extension UITableView {
+    static func standardList(style: UITableView.Style = .insetGrouped) -> UITableView {
+        let tableView = UITableView(frame: .zero, style: style)
+        tableView.applyStandardListAppearance()
+        return tableView
+    }
+
+    func applyStandardListAppearance() {
+        backgroundColor = UIColor.Main.background
+        separatorStyle = .singleLine
+        separatorColor = UIColor.TableView.separator
+        rowHeight = UITableView.automaticDimension
+        estimatedRowHeight = 56
+        sectionHeaderHeight = UITableView.automaticDimension
+        estimatedSectionHeaderHeight = 28
+
+        if #available(iOS 15.0, *) {
+            sectionHeaderTopPadding = 0
+        }
+    }
+}

--- a/TrackMyCafe/Services/Domain/DomainDB.swift
+++ b/TrackMyCafe/Services/Domain/DomainDB.swift
@@ -89,6 +89,7 @@ protocol DomainDB {
     // Purchases
     func fetchPurchases(completion: @escaping ([PurchaseModel]) -> Void)
     func savePurchase(model: PurchaseModel, completion: @escaping (Bool) -> Void)
+    func deletePurchase(model: PurchaseModel, completion: @escaping (Bool) -> Void)
 
     // Recipes
     func fetchRecipe(

--- a/TrackMyCafe/Services/Domain/DomainDatabaseService.swift
+++ b/TrackMyCafe/Services/Domain/DomainDatabaseService.swift
@@ -126,6 +126,24 @@ class DomainDatabaseService: DomainDB {
         }
     }
 
+    func deletePurchase(model: PurchaseModel, completion: @escaping (Bool) -> Void) {
+        FirestoreDatabaseService.shared.delete(
+            collection: FirebaseCollections.purchases,
+            documentId: model.id
+        ) { [weak self] result in
+            switch result {
+            case .success:
+                self?.logger.info("Purchase deleted from Firestore successfully")
+                completion(true)
+            case .failure(let error):
+                self?.logger.error(
+                    "Failed to delete purchase from Firestore with error: \(error.localizedDescription)"
+                )
+                completion(false)
+            }
+        }
+    }
+
     // Recipes
     func fetchRecipe(
         forProductId productId: String, completion: @escaping ([RecipeItemModel]) -> Void

--- a/TrackMyCafe/View Layer/Flow/Costs/CostList/View/CostListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Costs/CostList/View/CostListViewController.swift
@@ -11,17 +11,11 @@ class CostListViewController: UIViewController, Loggable, ProGated {
     private var viewModel: CostListViewModelType?
 
     let tableView: UITableView = {
-        let tableView = UITableView(frame: .zero, style: .insetGrouped)
-
+        let tableView = UITableView.standardList()
         tableView.register(
-            CostsTableViewCell.self, forCellReuseIdentifier: CostsTableViewCell.identifier)
-        tableView.backgroundColor = UIColor.Main.background
-        tableView.separatorStyle = .singleLine
-        tableView.separatorColor = UIColor.TableView.separator
-        tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = 56
-        tableView.translatesAutoresizingMaskIntoConstraints = false
-
+            CostsTableViewCell.self,
+            forCellReuseIdentifier: CostsTableViewCell.identifier
+        )
         return tableView
     }()
 

--- a/TrackMyCafe/View Layer/Flow/Inventory/StockList/View/StockItemCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Inventory/StockList/View/StockItemCell.swift
@@ -8,17 +8,14 @@
 import TinyConstraints
 import UIKit
 
-class StockItemCell: UITableViewCell {
+final class StockItemCell: BaseListTableViewCell {
 
     // MARK: - Views
 
-    private let containerView = UIView()
-
     private let nameLabel: AppLabel = {
-        let label = AppLabel(style: .bodyMedium)
-        label.textColor = UIColor.Main.text
+        let label = AppLabel(style: .bodyMultiline)
+        label.textColor = UIColor.TableView.cellLabel
         label.numberOfLines = 2
-        label.lineBreakMode = .byWordWrapping
         return label
     }()
 
@@ -29,8 +26,8 @@ class StockItemCell: UITableViewCell {
     }()
 
     private let quantityLabel: AppLabel = {
-        let label = AppLabel(style: .bodyBoldValue)
-        label.textColor = UIColor.Main.text
+        let label = AppLabel(style: .bodyValue)
+        label.textColor = UIColor.TableView.cellLabel
         label.textAlignment = .right
         return label
     }()
@@ -45,22 +42,18 @@ class StockItemCell: UITableViewCell {
     // MARK: - Init
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        super.init(style: .default, reuseIdentifier: reuseIdentifier)
         setupUI()
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
 
     // MARK: - Setup
 
     private func setupUI() {
-        backgroundColor = .clear
-        selectionStyle = .none
-
-        contentView.addSubview(containerView)
-        containerView.edgesToSuperview()
+        accessoryType = .disclosureIndicator
 
         let infoStack = UIStackView(arrangedSubviews: [nameLabel, unitLabel])
         infoStack.axis = .vertical
@@ -79,7 +72,7 @@ class StockItemCell: UITableViewCell {
         rootStack.distribution = .fill
         rootStack.spacing = UIConstants.standardSpacing
 
-        containerView.addSubview(rootStack)
+        contentView.addSubview(rootStack)
         rootStack.edgesToSuperview(
             insets: .init(
                 top: UIConstants.standardSpacing,
@@ -96,27 +89,20 @@ class StockItemCell: UITableViewCell {
     // MARK: - Configuration
 
     func configure(with model: IngredientModel) {
-        // 1. Name + Unit
         nameLabel.text = "\(model.name), \(model.unit.localizedName)"
 
-        // 2. Quantity (was at top right)
         quantityLabel.text = String(format: "%.2f", model.stockQuantity)
 
-        // 3. Average Price (was at bottom right) -> now below Name
         unitLabel.text = String(
             format: R.string.global.inventoryAvgPrice(model.averageCost), model.averageCost)
-        unitLabel.textColor = UIColor.Main.secondaryText
 
-        // 4. Total Value (new) -> now at bottom right
         let totalValue = model.stockQuantity * model.averageCost
         costLabel.text = String(format: R.string.global.inventorySumValue(totalValue), totalValue)
-        costLabel.textColor = UIColor.Main.secondaryText
 
-        // Highlight low stock (hardcoded threshold 5.0 for now, ideally from settings)
         if model.stockQuantity < 5.0 {
             quantityLabel.textColor = .systemRed
         } else {
-            quantityLabel.textColor = UIColor.Main.text
+            quantityLabel.textColor = UIColor.TableView.cellLabel
         }
     }
 }

--- a/TrackMyCafe/View Layer/Flow/Inventory/StockList/View/StockListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Inventory/StockList/View/StockListViewController.swift
@@ -15,12 +15,10 @@ class StockListViewController: UIViewController, ProGated {
     private let viewModel: StockListViewModelProtocol
 
     private lazy var tableView: UITableView = {
-        let tableView = UITableView()
+        let tableView = UITableView.standardList()
         tableView.register(StockItemCell.self, forCellReuseIdentifier: "StockItemCell")
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = 80
         tableView.tableFooterView = UIView()
         return tableView
     }()
@@ -64,8 +62,6 @@ class StockListViewController: UIViewController, ProGated {
 
         view.addSubview(tableView)
         view.addSubview(activityIndicator)
-
-        tableView.backgroundColor = UIColor.Main.background
 
         tableView.edgesToSuperview()
         activityIndicator.centerInSuperview()

--- a/TrackMyCafe/View Layer/Flow/ManualMovements/List/ManualMovementListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/ManualMovements/List/ManualMovementListViewController.swift
@@ -4,14 +4,7 @@ import UIKit
 final class ManualMovementListViewController: UIViewController, ProGated {
     private let viewModel: ManualMovementListViewModelType
 
-    private let tableView: UITableView = {
-        let tableView = UITableView(frame: .zero, style: .plain)
-        tableView.backgroundColor = UIColor.Main.background
-        tableView.separatorStyle = .singleLine
-        tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = 72
-        return tableView
-    }()
+    private let tableView = UITableView.standardList()
 
     private lazy var addButton: UIButton = {
         let button = UIButton(type: .system)
@@ -168,8 +161,10 @@ extension ManualMovementListViewController: UITableViewDelegate {
         forSection section: Int
     ) {
         guard let header = view as? UITableViewHeaderFooterView else { return }
-        header.textLabel?.applyDynamic(Typography.title3)
-        header.textLabel?.textColor = UIColor.Main.text.alpha(0.55)
+        header.textLabel?.font = Typography.footnote
+        header.textLabel?.textColor = UIColor.Main.text
+        if #available(iOS 11.0, *) {
+            header.textLabel?.adjustsFontForContentSizeCategory = true
+        }
     }
 }
-

--- a/TrackMyCafe/View Layer/Flow/ManualMovements/List/ManualMovementTableViewCell.swift
+++ b/TrackMyCafe/View Layer/Flow/ManualMovements/List/ManualMovementTableViewCell.swift
@@ -1,34 +1,25 @@
 import TinyConstraints
 import UIKit
 
-final class ManualMovementTableViewCell: UITableViewCell {
+final class ManualMovementTableViewCell: BaseListTableViewCell {
     static let reuseIdentifier = "ManualMovementTableViewCell"
 
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.applyDynamic(Typography.title3DemiBold)
-        label.textColor = UIColor.Main.text
-        label.numberOfLines = 1
-        label.adjustsFontSizeToFitWidth = true
-        label.minimumScaleFactor = 0.85
+    private let titleLabel: AppLabel = {
+        let label = AppLabel(style: .body)
+        label.textColor = UIColor.TableView.cellLabel
         return label
     }()
 
-    private let subtitleLabel: UILabel = {
-        let label = UILabel()
-        label.applyDynamic(Typography.footnote)
-        label.textColor = UIColor.Main.text.alpha(0.6)
+    private let subtitleLabel: AppLabel = {
+        let label = AppLabel(style: .footnote)
+        label.textColor = UIColor.Main.secondaryText
         label.numberOfLines = 2
         return label
     }()
 
-    private let amountLabel: UILabel = {
-        let label = UILabel()
-        label.applyDynamic(Typography.title3DemiBold)
+    private let amountLabel: AppLabel = {
+        let label = AppLabel(style: .bodyValue)
         label.textAlignment = .right
-        label.numberOfLines = 1
-        label.adjustsFontSizeToFitWidth = true
-        label.minimumScaleFactor = 0.6
         label.setContentCompressionResistancePriority(.required, for: .horizontal)
         label.setContentHuggingPriority(.required, for: .horizontal)
         return label
@@ -50,18 +41,16 @@ final class ManualMovementTableViewCell: UITableViewCell {
     }()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        super.init(style: .default, reuseIdentifier: reuseIdentifier)
         setupUI()
     }
 
     required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        setupUI()
+        return nil
     }
 
     private func setupUI() {
-        backgroundColor = UIColor.TableView.cellBackground
-        selectionStyle = .default
+        accessoryType = .disclosureIndicator
 
         vStack.addArrangedSubview(titleLabel)
         vStack.addArrangedSubview(subtitleLabel)
@@ -153,7 +142,7 @@ final class ManualMovementTableViewCell: UITableViewCell {
         case .transfer:
             prefix = ""
             currency = NumberFormatter.currencyInteger.string(abs(operation.amount))
-            color = UIColor.Main.text
+            color = UIColor.TableView.cellLabel
         case .adjustment:
             let raw = operation.amount
             prefix = raw >= 0 ? "+" : "-"
@@ -164,4 +153,3 @@ final class ManualMovementTableViewCell: UITableViewCell {
         return ("\(prefix)\(currency)", color)
     }
 }
-

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderProductPickerViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/View/OrderProductPickerViewController.swift
@@ -41,12 +41,7 @@ final class OrderProductPickerViewController: UIViewController, Loggable {
         return collectionView
     }()
 
-    private let tableView: UITableView = {
-        let tableView = UITableView(frame: .zero, style: .plain)
-        tableView.backgroundColor = UIColor.Main.background
-        tableView.separatorStyle = .singleLine
-        return tableView
-    }()
+    private let tableView = UITableView.standardList(style: .insetGrouped)
 
     private lazy var productsCollectionView: UICollectionView = {
         let collectionView = UICollectionView(
@@ -97,6 +92,10 @@ final class OrderProductPickerViewController: UIViewController, Loggable {
     }
 
     private func setupTableView() {
+        tableView.register(
+            OrderProductPickerTableViewCell.self,
+            forCellReuseIdentifier: OrderProductPickerTableViewCell.reuseIdentifier
+        )
         tableView.delegate = self
         tableView.dataSource = self
     }
@@ -317,16 +316,17 @@ extension OrderProductPickerViewController: UITableViewDataSource, UITableViewDe
         _ tableView: UITableView,
         cellForRowAt indexPath: IndexPath
     ) -> UITableViewCell {
-        let cell =
-            tableView.dequeueReusableCell(withIdentifier: "ProductCell")
-            ?? UITableViewCell(style: .value1, reuseIdentifier: "ProductCell")
+        guard
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: OrderProductPickerTableViewCell.reuseIdentifier,
+                for: indexPath
+            ) as? OrderProductPickerTableViewCell
+        else {
+            return UITableViewCell()
+        }
 
         let product = filteredProducts[indexPath.row]
-        cell.textLabel?.text = product.name
-        cell.detailTextLabel?.text = product.price.currency
-        cell.backgroundColor = UIColor.Main.background
-        cell.textLabel?.textColor = UIColor.Main.text
-        cell.detailTextLabel?.textColor = UIColor.Main.text
+        cell.configure(product: product)
         return cell
     }
 
@@ -341,5 +341,28 @@ extension OrderProductPickerViewController: UITableViewDataSource, UITableViewDe
                 self.navigationController?.popViewController(animated: true)
             }
         }
+    }
+}
+
+private final class OrderProductPickerTableViewCell: BaseListTableViewCell {
+    static let reuseIdentifier = "OrderProductPickerTableViewCell"
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .value1, reuseIdentifier: reuseIdentifier)
+        accessoryType = .none
+        textLabel?.applyDynamic(Typography.body)
+        detailTextLabel?.applyDynamic(Typography.body)
+        detailTextLabel?.adjustsFontSizeToFitWidth = true
+        detailTextLabel?.minimumScaleFactor = 0.7
+        detailTextLabel?.lineBreakMode = .byTruncatingTail
+    }
+
+    required init?(coder: NSCoder) {
+        return nil
+    }
+
+    func configure(product: ProductsPriceModel) {
+        textLabel?.text = product.name
+        detailTextLabel?.text = product.price.currency
     }
 }

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderList/View/OrderListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderList/View/OrderListViewController.swift
@@ -12,14 +12,11 @@ class OrderListViewController: UIViewController, Loggable, ProGated {
     private var viewModel: OrderListViewModelType?
 
     let tableView: UITableView = {
-        let tableView = UITableView(frame: .zero, style: .insetGrouped)
-
+        let tableView = UITableView.standardList()
         tableView.register(
-            OrdersTableViewCell.self, forCellReuseIdentifier: OrdersTableViewCell.identifier)
-        tableView.backgroundColor = UIColor.Main.background
-        tableView.separatorColor = UIColor.TableView.separator
-        // tableView.translatesAutoresizingMaskIntoConstraints = false // Not needed with TinyConstraints
-
+            OrdersTableViewCell.self,
+            forCellReuseIdentifier: OrdersTableViewCell.identifier
+        )
         return tableView
     }()
 

--- a/TrackMyCafe/View Layer/Flow/Purchase/PurchaseList/View/PurchaseListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Purchase/PurchaseList/View/PurchaseListViewController.swift
@@ -14,13 +14,9 @@ class PurchaseListViewController: UIViewController, ProGated {
 
     // MARK: - UI Elements
     private lazy var tableView: UITableView = {
-        let tableView = UITableView()
+        let tableView = UITableView.standardList()
         tableView.register(
             PurchaseTableViewCell.self, forCellReuseIdentifier: PurchaseTableViewCell.identifier)
-        tableView.backgroundColor = UIColor.Main.background
-        tableView.separatorStyle = .singleLine
-        tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = 72
         return tableView
     }()
 
@@ -385,11 +381,52 @@ extension PurchaseListViewController: UITableViewDelegate {
 
     func tableView(
         _ tableView: UITableView,
+        trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
+    ) -> UISwipeActionsConfiguration? {
+        let deleteAction = UIContextualAction(
+            style: .destructive,
+            title: R.string.global.delete()
+        ) { [weak self] _, _, completion in
+            guard let self else {
+                completion(false)
+                return
+            }
+
+            self.checkProOrShowPaywall(
+                onSuccess: { [weak self] in
+                    guard let self else {
+                        completion(false)
+                        return
+                    }
+
+                    self.viewModel.deletePurchase(at: indexPath) { [weak self] success in
+                        DispatchQueue.main.async {
+                            if success {
+                                self?.tableView.reloadData()
+                            }
+                            completion(success)
+                        }
+                    }
+                },
+                onDenied: {
+                    completion(false)
+                }
+            )
+        }
+
+        return UISwipeActionsConfiguration(actions: [deleteAction])
+    }
+
+    func tableView(
+        _ tableView: UITableView,
         willDisplayHeaderView view: UIView,
         forSection section: Int
     ) {
         guard let header = view as? UITableViewHeaderFooterView else { return }
-        header.textLabel?.applyDynamic(Typography.title3)
-        header.textLabel?.textColor = UIColor.Main.text.alpha(0.55)
+        header.textLabel?.font = Typography.footnote
+        header.textLabel?.textColor = UIColor.Main.text
+        if #available(iOS 11.0, *) {
+            header.textLabel?.adjustsFontForContentSizeCategory = true
+        }
     }
 }

--- a/TrackMyCafe/View Layer/Flow/Purchase/PurchaseList/View/PurchaseTableViewCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Purchase/PurchaseList/View/PurchaseTableViewCell.swift
@@ -5,52 +5,46 @@
 //  Created by AI Assistant on 10.02.2026.
 //
 
-import UIKit
 import TinyConstraints
+import UIKit
 
-class PurchaseTableViewCell: UITableViewCell {
+final class PurchaseTableViewCell: BaseListTableViewCell {
 
     // MARK: - UI Elements
     private let nameLabel: AppLabel = {
-        let label = AppLabel(style: .bodyMedium)
-        label.textColor = UIColor.Main.text
+        let label = AppLabel(style: .bodyMultiline)
+        label.textColor = UIColor.TableView.cellLabel
         label.numberOfLines = 2
-        label.lineBreakMode = .byWordWrapping
         return label
     }()
 
     private let detailsLabel: AppLabel = {
         let label = AppLabel(style: .footnoteValue)
-        label.textColor = UIColor.Main.text.alpha(0.75)
+        label.textColor = UIColor.Main.secondaryText
         label.textAlignment = .right
         return label
     }()
 
     private let totalLabel: AppLabel = {
-        let label = AppLabel(style: .bodyBoldValue)
-        label.textColor = UIColor.Main.text
+        let label = AppLabel(style: .bodyValue)
+        label.textColor = UIColor.TableView.cellLabel
         label.textAlignment = .right
         return label
     }()
 
-    private let containerView: UIView = {
-        UIView()
-    }()
-
     // MARK: - Init
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        super.init(style: .default, reuseIdentifier: reuseIdentifier)
         setupView()
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
 
     // MARK: - Setup
     private func setupView() {
-        backgroundColor = .clear
-        contentView.backgroundColor = .clear
+        accessoryType = .disclosureIndicator
 
         let leftStack = UIStackView(arrangedSubviews: [nameLabel])
         leftStack.axis = .vertical
@@ -68,14 +62,11 @@ class PurchaseTableViewCell: UITableViewCell {
 
         let rootStack = UIStackView(arrangedSubviews: [leftStack, rightStack])
         rootStack.axis = .horizontal
-        rootStack.alignment = .top
+        rootStack.alignment = .center
         rootStack.distribution = .fill
         rootStack.spacing = UIConstants.standardSpacing
 
-        contentView.addSubview(containerView)
-        containerView.addSubview(rootStack)
-
-        containerView.edgesToSuperview()
+        contentView.addSubview(rootStack)
         rootStack.edgesToSuperview(
             insets: .init(
                 top: UIConstants.standardSpacing,

--- a/TrackMyCafe/View Layer/Flow/Purchase/PurchaseList/ViewModel/PurchaseListViewModel.swift
+++ b/TrackMyCafe/View Layer/Flow/Purchase/PurchaseList/ViewModel/PurchaseListViewModel.swift
@@ -14,6 +14,7 @@ protocol PurchaseListViewModelType {
     func numberOfRowInSection(for section: Int) -> Int
     func cellViewModel(for indexPath: IndexPath) -> PurchaseListItemViewModelType?
     func purchase(at indexPath: IndexPath) -> PurchaseModel
+    func deletePurchase(at indexPath: IndexPath, completion: @escaping (Bool) -> Void)
     func availableIngredients() -> [(id: String, name: String)]
     func applyFilter(
         dateRange: ClosedRange<Date>?,
@@ -92,6 +93,24 @@ class PurchaseListViewModel: PurchaseListViewModelType {
 
     func purchase(at indexPath: IndexPath) -> PurchaseModel {
         return sectionsPurchases[indexPath.section].items[indexPath.row]
+    }
+
+    func deletePurchase(at indexPath: IndexPath, completion: @escaping (Bool) -> Void) {
+        let model = purchase(at: indexPath)
+
+        dbService.deletePurchase(model: model) { [weak self] success in
+            guard let self else {
+                completion(false)
+                return
+            }
+
+            if success {
+                self.allPurchases.removeAll { $0.id == model.id }
+                self.applyCurrentFilters()
+            }
+
+            completion(success)
+        }
     }
 
     func applyFilter(

--- a/TrackMyCafe/View Layer/Flow/Settings/Ingredients/View/IngredientListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/Ingredients/View/IngredientListViewController.swift
@@ -13,14 +13,10 @@ class IngredientListViewController: UIViewController {
     private let viewModel: IngredientListViewModelType
     
     private lazy var tableView: UITableView = {
-        let tableView = UITableView()
+        let tableView = UITableView.standardList()
         tableView.delegate = self
         tableView.dataSource = self
         tableView.register(IngredientTableViewCell.self, forCellReuseIdentifier: IngredientTableViewCell.identifier)
-        tableView.backgroundColor = UIColor.Main.background
-        tableView.separatorStyle = .singleLine
-        tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = 70
         return tableView
     }()
 
@@ -50,7 +46,7 @@ class IngredientListViewController: UIViewController {
         title = viewModel.title
         
         view.addSubview(tableView)
-        tableView.edgesToSuperview()
+        tableView.edgesToSuperview(usingSafeArea: true)
         
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(addIngredientAction))
     }

--- a/TrackMyCafe/View Layer/Flow/Settings/Ingredients/View/IngredientTableViewCell.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/Ingredients/View/IngredientTableViewCell.swift
@@ -8,55 +8,51 @@
 import TinyConstraints
 import UIKit
 
-class IngredientTableViewCell: UITableViewCell {
+final class IngredientTableViewCell: BaseListTableViewCell {
 
     static let identifier = "IngredientTableViewCell"
 
     // MARK: - UI Elements
-    private let nameLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 16, weight: .medium)
-        label.textColor = UIColor.Main.text
+    private let nameLabel: AppLabel = {
+        let label = AppLabel(style: .bodyMultiline)
+        label.textColor = UIColor.TableView.cellLabel
+        label.numberOfLines = 2
         return label
     }()
 
-    private let stockLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 12, weight: .regular)
-        label.textColor = UIColor.gray
+    private let stockLabel: AppLabel = {
+        let label = AppLabel(style: .footnote)
+        label.textColor = UIColor.Main.secondaryText
         return label
     }()
 
-    private let costLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 16, weight: .bold)
-        label.textColor = UIColor.Main.text
+    private let costLabel: AppLabel = {
+        let label = AppLabel(style: .bodyValue)
+        label.textColor = UIColor.TableView.cellLabel
         label.textAlignment = .right
         return label
     }()
 
-    private let unitLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 14, weight: .regular)
-        label.textColor = UIColor.Main.text
+    private let unitLabel: AppLabel = {
+        let label = AppLabel(style: .footnoteValue)
+        label.textColor = UIColor.Main.secondaryText
         label.textAlignment = .right
         return label
     }()
 
     // MARK: - Init
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        super.init(style: .default, reuseIdentifier: reuseIdentifier)
         setupView()
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
 
     // MARK: - Setup
     private func setupView() {
-        backgroundColor = .clear
-        contentView.backgroundColor = .clear
+        accessoryType = .disclosureIndicator
 
         contentView.addSubview(nameLabel)
         contentView.addSubview(stockLabel)

--- a/TrackMyCafe/View Layer/Flow/Settings/ProductCategories/ProductCategoriesListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/ProductCategories/ProductCategoriesListViewController.swift
@@ -5,10 +5,7 @@ final class ProductCategoriesListViewController: UIViewController, Loggable {
     private var categories: [ProductCategoryModel] = []
 
     private let tableView: UITableView = {
-        let tableView = UITableView(frame: .zero, style: .insetGrouped)
-        tableView.backgroundColor = UIColor.Main.background
-        tableView.separatorStyle = .singleLine
-        return tableView
+        UITableView.standardList()
     }()
 
     override func viewWillAppear(_ animated: Bool) {

--- a/TrackMyCafe/View Layer/Flow/Settings/Products/ProductList/View/ProductListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/Products/ProductList/View/ProductListViewController.swift
@@ -22,10 +22,7 @@ class ProductListViewController: UIViewController, Loggable {
     private var currentSortOrder: ProductSortOrder = .none
     
     let tableView: UITableView = {
-        let tableView = UITableView()
-        tableView.backgroundColor = UIColor.Main.background
-        tableView.separatorStyle = .none
-        tableView.rowHeight = 44
+        let tableView = UITableView.standardList()
         tableView.translatesAutoresizingMaskIntoConstraints = false
         
         return tableView
@@ -147,9 +144,9 @@ class ProductListViewController: UIViewController, Loggable {
         view.addSubview(tableView)
         
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: 10),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10),
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0),
         ])
         

--- a/TrackMyCafe/View Layer/Flow/Settings/SettingList/View/SettingListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/SettingList/View/SettingListViewController.swift
@@ -54,9 +54,7 @@ class SettingListViewController: UIViewController, UITableViewDelegate, UITableV
     private let subscriptionBanner = SubscriptionBannerView()
     
     private let tableView: UITableView = {
-        let tableView = UITableView(frame: .zero, style: .insetGrouped)
-        tableView.backgroundColor = UIColor.Main.background
-        tableView.separatorStyle = .singleLine
+        let tableView = UITableView.standardList()
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.register(
             SettingsStaticTableViewCell.self,

--- a/TrackMyCafe/View Layer/Flow/Settings/Types/TypeList/View/TypesListViewController.swift
+++ b/TrackMyCafe/View Layer/Flow/Settings/Types/TypeList/View/TypesListViewController.swift
@@ -15,11 +15,7 @@ class TypesListViewController: UIViewController, Loggable {
     var types = [TypeModel]()
 
     let tableView: UITableView = {
-        let tableView = UITableView(frame: .zero, style: .insetGrouped)
-        tableView.backgroundColor = UIColor.Main.background
-        tableView.separatorStyle = .singleLine
-
-        return tableView
+        UITableView.standardList()
     }()
 
     override func viewWillAppear(_ animated: Bool) {
@@ -81,10 +77,6 @@ extension TypesListViewController: UITableViewDelegate, UITableViewDataSource {
         cell.configure(type: types[indexPath.row], indexPath: indexPath)
 
         return cell
-    }
-
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 44
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {


### PR DESCRIPTION
## Title

- Use Conventional Commits: `fix(ui): standardize table view lists and restore purchase deletion`

## Plan

- Audit table-based list screens against the standard `Costs` presentation.
- Introduce a shared default `UITableView` configuration for standard list screens.
- Migrate non-standard list screens and restore missing purchase row deletion.

## Code

- Added `UITableView+StandardList.swift` and wired it into the default list-style screens.
- Unified list cells for inventory, purchases, manual movements, ingredients, product categories, product list, types, settings, costs, orders, and the iPhone product picker to match the standard table view appearance.
- Restored purchase deletion through `PurchaseListViewController`, `PurchaseListViewModel`, `DomainDB`, and `DomainDatabaseService`.
- Adjusted purchase row layout so the product title is vertically centered relative to the amount/details block.

## Expected outcome

- Standard list-based screens use the same grouped table appearance and cell styling as the `Costs` screen.
- Purchase rows can be deleted again via swipe actions.
- Purchase cell content reads more naturally, with the left title aligned vertically to the right-side values.

## Validation

- Checked IDE diagnostics after edits: no diagnostics reported.
- Verified git working tree is clean after commit.
- UI note: please run the iOS Simulator in Xcode to visually verify any UI changes.
- Build note: `xcodebuild` in this environment is blocked during package resolution by sandbox restrictions (`sandbox-exec: sandbox_apply: Operation not permitted`).

## References

- Closes #224