### PR TITLE
fix(ui): standardize table view lists and restore purchase deletion

### DIFF
--- a/TrackMyCafe.xcodeproj/project.pbxproj
+++ b/TrackMyCafe.xcodeproj/project.pbxproj
@@ -3895,7 +3895,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACH_O_TYPE = mh_execute;
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = ICSOFT.TrackMyCafe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -3928,7 +3928,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACH_O_TYPE = mh_execute;
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = ICSOFT.TrackMyCafe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -3959,7 +3959,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = ICSOFT.TrackMyCafe.beta;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -3989,7 +3989,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = ICSOFT.TrackMyCafe.beta;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -4020,7 +4020,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = ICSOFT.TrackMyCafe.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -4050,7 +4050,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = ICSOFT.TrackMyCafe.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/TrackMyCafe/Configuration/TrackMyCafe Beta/Info.plist
+++ b/TrackMyCafe/Configuration/TrackMyCafe Beta/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>48</string>
+	<string>49</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSFaceIDUsageDescription</key>

--- a/TrackMyCafe/Configuration/TrackMyCafe Beta/Info.plist
+++ b/TrackMyCafe/Configuration/TrackMyCafe Beta/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>47</string>
+	<string>48</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSFaceIDUsageDescription</key>

--- a/TrackMyCafe/Configuration/TrackMyCafe Dev/Info.plist
+++ b/TrackMyCafe/Configuration/TrackMyCafe Dev/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>48</string>
+	<string>49</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSFaceIDUsageDescription</key>

--- a/TrackMyCafe/Configuration/TrackMyCafe Dev/Info.plist
+++ b/TrackMyCafe/Configuration/TrackMyCafe Dev/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>47</string>
+	<string>48</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSFaceIDUsageDescription</key>

--- a/TrackMyCafe/Configuration/TrackMyCafe Prod/Info.plist
+++ b/TrackMyCafe/Configuration/TrackMyCafe Prod/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>48</string>
+	<string>49</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSFaceIDUsageDescription</key>

--- a/TrackMyCafe/Configuration/TrackMyCafe Prod/Info.plist
+++ b/TrackMyCafe/Configuration/TrackMyCafe Prod/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>47</string>
+	<string>48</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSFaceIDUsageDescription</key>


### PR DESCRIPTION
## Title

- Use Conventional Commits: `fix(ui): standardize table view lists and restore purchase deletion`

## Plan

- Standardize list-style table screens around the shared table view setup.
- Restore purchase deletion flow and related purchase list behavior.
- Bump the marketing version to `1.0.8` for the next App Store Connect upload.

## Code

- Added shared list/table setup support in `UITableView+StandardList.swift` and applied it across multiple list screens.
- Updated purchase list flow, including deletion support and related UI/view model wiring.
- Cleaned up several table view cells/controllers for more consistent list rendering.
- Updated `MARKETING_VERSION` to `1.0.8` in project build settings so `CFBundleShortVersionString` resolves to the new release version.

## Expected outcome

- Table-based list screens behave more consistently across the app.
- Purchase deletion works again from the purchase list flow.
- The next archive/upload uses marketing version `1.0.8` instead of the closed `1.0.7` App Store Connect train.

## Validation

- Branch diff reviewed against `origin/main`.
- Version bump commit pushed successfully to `feat/224-unify-tableview-standard`.
- App Store Connect upload error analysis confirmed `CFBundleShortVersionString` needed to be raised above `1.0.7`.
- UI note: please run the iOS Simulator in Xcode to visually verify list layouts and purchase deletion flow.

## References

- Refs #224