### PR TITLE
feat(finance): lock historical COGS snapshot for orders

### DIFF
--- a/TrackMyCafe.xcodeproj/project.pbxproj
+++ b/TrackMyCafe.xcodeproj/project.pbxproj
@@ -289,6 +289,9 @@
 		F363F28E2FEE7C1800910F20 /* UITableView+StandardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F28D2FEE7C1800910F20 /* UITableView+StandardList.swift */; };
 		F363F28F2FEE7C1800910F20 /* UITableView+StandardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F28D2FEE7C1800910F20 /* UITableView+StandardList.swift */; };
 		F363F2902FEE7C1800910F20 /* UITableView+StandardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F28D2FEE7C1800910F20 /* UITableView+StandardList.swift */; };
+		F363F45E2FF11C2800910F20 /* OrderSnapshotRepairService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F45D2FF11C2800910F20 /* OrderSnapshotRepairService.swift */; };
+		F363F45F2FF11C2800910F20 /* OrderSnapshotRepairService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F45D2FF11C2800910F20 /* OrderSnapshotRepairService.swift */; };
+		F363F4602FF11C2800910F20 /* OrderSnapshotRepairService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363F45D2FF11C2800910F20 /* OrderSnapshotRepairService.swift */; };
 		F36DA6AB2F3B57C000CE345C /* IngredientTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36DA6AA2F3B57C000CE345C /* IngredientTableViewCell.swift */; };
 		F36DA6AC2F3B57C000CE345C /* IngredientTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36DA6AA2F3B57C000CE345C /* IngredientTableViewCell.swift */; };
 		F36DA6AD2F3B57C000CE345C /* IngredientTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36DA6AA2F3B57C000CE345C /* IngredientTableViewCell.swift */; };
@@ -921,6 +924,7 @@
 		F36217CC2EC04E5300965886 /* DomainProductPriceDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainProductPriceDataService.swift; sourceTree = "<group>"; };
 		F363F2892FED4E2D00910F20 /* FinanceHistoryBackfillService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinanceHistoryBackfillService.swift; sourceTree = "<group>"; };
 		F363F28D2FEE7C1800910F20 /* UITableView+StandardList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+StandardList.swift"; sourceTree = "<group>"; };
+		F363F45D2FF11C2800910F20 /* OrderSnapshotRepairService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSnapshotRepairService.swift; sourceTree = "<group>"; };
 		F36DA6AA2F3B57C000CE345C /* IngredientTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngredientTableViewCell.swift; sourceTree = "<group>"; };
 		F371AA7727589CFB0059710A /* SettingsDataTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDataTableViewCell.swift; sourceTree = "<group>"; };
 		F371AA7A2758B0890059710A /* UIViewController+AlertLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+AlertLanguage.swift"; sourceTree = "<group>"; };
@@ -2294,6 +2298,7 @@
 		F3E357E72BEFA203005050CB /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				F363F45D2FF11C2800910F20 /* OrderSnapshotRepairService.swift */,
 				F363F2892FED4E2D00910F20 /* FinanceHistoryBackfillService.swift */,
 				F371BEDD2FED42B800D72C3A /* DomainManualMovementService.swift */,
 				F3F205522FD831A0007249FB /* DomainProductCategoryDataService.swift */,
@@ -3076,6 +3081,7 @@
 				F3E16E922BF89FC20008BD6A /* SettingsManager.swift in Sources */,
 				F3F6A6372C327B83000961C8 /* AdminDetailsController.swift in Sources */,
 				F3E358032BF22B76005050CB /* DomainDB.swift in Sources */,
+				F363F45E2FF11C2800910F20 /* OrderSnapshotRepairService.swift in Sources */,
 				F35E91AB2F49D7A80050EB4A /* FIRProductCategoryModel.swift in Sources */,
 				F3A640B02C3408A3006BCACD /* SubscriptionController.swift in Sources */,
 				F316A2F3273803CE0083E830 /* ProductListViewController.swift in Sources */,
@@ -3301,6 +3307,7 @@
 				F3B339E32C0B22FE0073F19A /* Settings.swift in Sources */,
 				F3B339E42C0B22FE0073F19A /* CostListViewController.swift in Sources */,
 				F3B339E52C0B22FE0073F19A /* TypesListViewController.swift in Sources */,
+				F363F45F2FF11C2800910F20 /* OrderSnapshotRepairService.swift in Sources */,
 				F35E91AA2F49D7A80050EB4A /* FIRProductCategoryModel.swift in Sources */,
 				F3A640B12C3408A3006BCACD /* SubscriptionController.swift in Sources */,
 				F3B339E62C0B22FE0073F19A /* SettingsDataTableViewCell.swift in Sources */,
@@ -3526,6 +3533,7 @@
 				F3B33A822C0B23450073F19A /* Settings.swift in Sources */,
 				F3B33A832C0B23450073F19A /* CostListViewController.swift in Sources */,
 				F3B33A842C0B23450073F19A /* TypesListViewController.swift in Sources */,
+				F363F4602FF11C2800910F20 /* OrderSnapshotRepairService.swift in Sources */,
 				F35E91AC2F49D7A80050EB4A /* FIRProductCategoryModel.swift in Sources */,
 				F3A640B22C3408A3006BCACD /* SubscriptionController.swift in Sources */,
 				F3B33A852C0B23450073F19A /* SettingsDataTableViewCell.swift in Sources */,

--- a/TrackMyCafe/Data Layer/Models/Domain/OrderItemModel.swift
+++ b/TrackMyCafe/Data Layer/Models/Domain/OrderItemModel.swift
@@ -11,23 +11,31 @@ struct OrderItemModel: Identifiable, Codable {
     let id: String
     let productId: String
     let quantity: Int
-    let salePrice: Double    // Price at the moment of sale
-    let costPrice: Double    // COGS at the moment of sale
-    
+    let salePrice: Double  // Price at the moment of sale
+    let costPrice: Double  // COGS at the moment of sale
+
     var totalSale: Double { salePrice * Double(quantity) }
     var totalCost: Double { costPrice * Double(quantity) }
-    
+
     init(
         id: String = UUID().uuidString,
         productId: String,
         quantity: Int,
         salePrice: Double,
-        costPrice: Double = 0.0 // Can be calculated later or passed during creation
+        costPrice: Double = 0.0  // Can be calculated later or passed during creation
     ) {
         self.id = id
         self.productId = productId
         self.quantity = quantity
         self.salePrice = salePrice
         self.costPrice = costPrice
+    }
+
+    init(product: ProductOfOrderModel) {
+        self.id = product.id
+        self.productId = product.productId
+        self.quantity = product.quantity
+        self.salePrice = product.price
+        self.costPrice = product.costPrice
     }
 }

--- a/TrackMyCafe/Data Layer/Models/Domain/ProductOfOrderModel.swift
+++ b/TrackMyCafe/Data Layer/Models/Domain/ProductOfOrderModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ProductOfOrderModel {
+struct ProductOfOrderModel: Equatable {
     var id: String
     var productId: String
     var orderId: String
@@ -56,5 +56,22 @@ struct ProductOfOrderModel {
         self.sum = firebaseModel.amount
         self.costPrice = firebaseModel.costPrice
         self.costSum = firebaseModel.costSum
+    }
+
+    var orderItemSnapshot: OrderItemModel {
+        OrderItemModel(product: self)
+    }
+
+    var hasCostSnapshot: Bool {
+        abs(costPrice) >= 0.000_1 || abs(costSum) >= 0.000_1
+    }
+
+    mutating func apply(snapshot: OrderItemModel) {
+        productId = snapshot.productId
+        quantity = snapshot.quantity
+        price = snapshot.salePrice
+        sum = snapshot.totalSale
+        costPrice = snapshot.costPrice
+        costSum = snapshot.totalCost
     }
 }

--- a/TrackMyCafe/Services/Domain/CostingService.swift
+++ b/TrackMyCafe/Services/Domain/CostingService.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol CostingServiceProtocol {
     func calculateProductCost(productId: String, completion: @escaping (Double) -> Void)
     func calculateOrderCOGS(items: [OrderItemModel], completion: @escaping (Double) -> Void)
+    func calculateOrderMetrics(items: [OrderItemModel]) -> (totalSale: Double, totalCost: Double)
 }
 
 class CostingService: CostingServiceProtocol {
@@ -65,5 +66,11 @@ class CostingService: CostingServiceProtocol {
         group.notify(queue: .main) {
             completion(totalOrderCOGS)
         }
+    }
+
+    func calculateOrderMetrics(items: [OrderItemModel]) -> (totalSale: Double, totalCost: Double) {
+        let totalSale = items.reduce(0) { $0 + $1.totalSale }
+        let totalCost = items.reduce(0) { $0 + $1.totalCost }
+        return (totalSale, totalCost)
     }
 }

--- a/TrackMyCafe/Services/Domain/DomainDB.swift
+++ b/TrackMyCafe/Services/Domain/DomainDB.swift
@@ -23,6 +23,7 @@ protocol DomainDB {
 
     // Order Products (ProductOfOrder)
     func fetchProduct(withOrderId id: String, completion: @escaping ([ProductOfOrderModel]) -> Void)
+    func fetchOrderItems(withOrderId id: String, completion: @escaping ([OrderItemModel]) -> Void)
     func saveProduct(order: ProductOfOrderModel, completion: @escaping (String?) -> Void)
     func deleteProduct(order: ProductOfOrderModel, completion: @escaping (Bool) -> Void)
 

--- a/TrackMyCafe/Services/Domain/DomainDatabaseService.swift
+++ b/TrackMyCafe/Services/Domain/DomainDatabaseService.swift
@@ -14,6 +14,7 @@ class DomainDatabaseService: DomainDB {
     static let shared = DomainDatabaseService()
     private let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier!, category: "DomainDatabaseService")
+    private let orderSnapshotRepairService = OrderSnapshotRepairService()
 
     // Метод для перевірки, чи включений режим онлайн
     // private func isOnlineModeEnabled() -> Bool {
@@ -231,19 +232,43 @@ class DomainDatabaseService: DomainDB {
 
     func fetchProduct(withOrderId id: String, completion: @escaping ([ProductOfOrderModel]) -> Void)
     {
-        FirestoreDatabaseService.shared.read(
-            collection: FirebaseCollections.productOfOrders, firModel: FIRProductModel.self
+        guard !id.isEmpty else {
+            completion([])
+            return
+        }
+
+        FirestoreDatabaseService.shared.readWhere(
+            collection: FirebaseCollections.productOfOrders,
+            firModel: FIRProductModel.self,
+            equalTo: ["orderId": id]
         ) { result in
             switch result {
             case .success(let firProducts):
-                let ordersProduct = firProducts.map { ProductOfOrderModel(firebaseModel: $0.1) }
-                let filteredProduct = ordersProduct.filter { $0.orderId == id }
-                completion(filteredProduct)
+                let products = firProducts.map { ProductOfOrderModel(firebaseModel: $0.1) }
+                self.fetchOrders(forId: id) { order in
+                    guard let order else {
+                        completion(products)
+                        return
+                    }
+
+                    let repairedSnapshot = self.orderSnapshotRepairService.repair(
+                        order: order,
+                        products: products
+                    )
+                    self.persistRepairedSnapshotIfNeeded(repairedSnapshot)
+                    completion(repairedSnapshot.products)
+                }
             case .failure(let error):
                 self.logger.error(
                     "Error fetching products from Firestore: \(error.localizedDescription)")
                 completion([])
             }
+        }
+    }
+
+    func fetchOrderItems(withOrderId id: String, completion: @escaping ([OrderItemModel]) -> Void) {
+        fetchProduct(withOrderId: id) { products in
+            completion(products.map(\.orderItemSnapshot))
         }
     }
 
@@ -327,63 +352,97 @@ class DomainDatabaseService: DomainDB {
     }
 
     func fetchOrders(completion: @escaping ([OrderModel]) -> Void) {
+        let group = DispatchGroup()
+        var fetchedOrders: [OrderModel] = []
+        var fetchedProducts: [ProductOfOrderModel] = []
+        var ordersError: Error?
+        var productsError: Error?
+
+        group.enter()
         FirestoreDatabaseService.shared.read(
-            collection: FirebaseCollections.orders, firModel: FIROrderModel.self
-        ) {
-            result in
+            collection: FirebaseCollections.orders,
+            firModel: FIROrderModel.self
+        ) { result in
+            defer { group.leave() }
             switch result {
             case .success(let firOrders):
-                let orders = firOrders.map { OrderModel(firebaseModel: $1) }
-                completion(orders)
+                fetchedOrders = firOrders.map { OrderModel(firebaseModel: $1) }
             case .failure(let error):
-                self.logger.error(
-                    "Error fetching products from Firestore: \(error.localizedDescription)")
-                completion([])
+                ordersError = error
             }
+        }
+
+        group.enter()
+        FirestoreDatabaseService.shared.read(
+            collection: FirebaseCollections.productOfOrders,
+            firModel: FIRProductModel.self
+        ) { result in
+            defer { group.leave() }
+            switch result {
+            case .success(let firProducts):
+                fetchedProducts = firProducts.map { ProductOfOrderModel(firebaseModel: $0.1) }
+            case .failure(let error):
+                productsError = error
+            }
+        }
+
+        group.notify(queue: .main) {
+            if let ordersError {
+                self.logger.error(
+                    "Error fetching orders from Firestore: \(ordersError.localizedDescription)")
+                completion([])
+                return
+            }
+
+            if let productsError {
+                self.logger.error(
+                    "Error fetching order items from Firestore: \(productsError.localizedDescription)"
+                )
+            }
+
+            let productsByOrderId = Dictionary(grouping: fetchedProducts) { $0.orderId }
+            let repairedOrders = fetchedOrders.map { order in
+                let repairResult = self.orderSnapshotRepairService.repair(
+                    order: order,
+                    products: productsByOrderId[order.id] ?? []
+                )
+                self.persistRepairedSnapshotIfNeeded(repairResult)
+                return repairResult.order
+            }
+            completion(repairedOrders)
         }
     }
 
     func fetchSectionsOfOrders(completion: @escaping ([(date: Date, items: [OrderModel])]) -> Void)
     {
-        FirestoreDatabaseService.shared.read(
-            collection: FirebaseCollections.orders, firModel: FIROrderModel.self
-        ) {
-            result in
-            switch result {
-            case .success(let firOrders):
-                let calendar = Calendar.current
-                let groupedOrders = Dictionary(
-                    grouping: firOrders.map { OrderModel(firebaseModel: $1) },
-                    by: { order -> Date in
-                        let dateComponents = calendar.dateComponents(
-                            [.year, .month, .day], from: order.date)
-                        return calendar.date(from: dateComponents)!
-                    })
-                let sections = groupedOrders.map { (date: $0.key, items: $0.value) }
-                    .sorted { $0.date > $1.date }
-                completion(sections)
-            case .failure(let error):
-                self.logger.error(
-                    "Error fetching orders from Firestore: \(error.localizedDescription)")
-                completion([])
-            }
+        fetchOrders { orders in
+            let calendar = Calendar.current
+            let groupedOrders = Dictionary(
+                grouping: orders,
+                by: { order -> Date in
+                    let dateComponents = calendar.dateComponents(
+                        [.year, .month, .day], from: order.date)
+                    return calendar.date(from: dateComponents)
+                        ?? calendar.startOfDay(for: order.date)
+                })
+            let sections = groupedOrders.map { (date: $0.key, items: $0.value) }
+                .sorted { $0.date > $1.date }
+            completion(sections)
         }
     }
 
     func fetchOrders(forId id: String, completion: @escaping (OrderModel?) -> Void) {
-        FirestoreDatabaseService.shared.read(
-            collection: FirebaseCollections.orders, firModel: FIROrderModel.self
-        ) {
-            result in
+        FirestoreDatabaseService.shared.fetchObjectById(
+            ofType: FIROrderModel.self,
+            collection: FirebaseCollections.orders,
+            id: id
+        ) { result in
             switch result {
-            case .success(let firOrders):
-                let orders = firOrders.map { OrderModel(firebaseModel: $1) }
-                completion(
-                    orders.filter { $0.id == id }
-                        .first)
+            case .success(let firOrder):
+                completion(OrderModel(firebaseModel: firOrder))
             case .failure(let error):
                 self.logger.error(
-                    "Error fetching orders from Firestore: \(error.localizedDescription)")
+                    "Error fetching order by id from Firestore: \(error.localizedDescription)")
                 completion(nil)
             }
         }
@@ -986,6 +1045,37 @@ class DomainDatabaseService: DomainDB {
     }
 }
 
+extension DomainDatabaseService {
+    fileprivate func persistRepairedSnapshotIfNeeded(_ snapshot: OrderSnapshotRepairResult) {
+        if snapshot.didRepairOrder {
+            updateOrder(snapshot.order) { [weak self] success in
+                if !success {
+                    self?.logger.error(
+                        "Failed to persist repaired order snapshot: \(snapshot.order.id)")
+                }
+            }
+        }
+
+        if snapshot.didRepairProducts {
+            snapshot.products.forEach { product in
+                self.persistRepairedProduct(product)
+            }
+        }
+    }
+
+    fileprivate func persistRepairedProduct(_ product: ProductOfOrderModel) {
+        FirestoreDatabaseService.shared.update(
+            firModel: FIRProductModel(dataModel: product),
+            collection: FirebaseCollections.productOfOrders,
+            documentId: product.id
+        ) { [weak self] result in
+            if case .failure(let error) = result {
+                self?.logger.error(
+                    "Failed to persist repaired order item snapshot: \(error.localizedDescription)")
+            }
+        }
+    }
+}
 // MARK: - Seeding Helpers
 extension DomainDatabaseService {
 

--- a/TrackMyCafe/Services/Domain/OrderSnapshotRepairService.swift
+++ b/TrackMyCafe/Services/Domain/OrderSnapshotRepairService.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+struct OrderSnapshotRepairResult {
+    let order: OrderModel
+    let products: [ProductOfOrderModel]
+    let didRepairProducts: Bool
+    let didRepairOrder: Bool
+}
+
+struct OrderSnapshotRepairService {
+    func repair(order: OrderModel, products: [ProductOfOrderModel]) -> OrderSnapshotRepairResult {
+        let repairedProducts = repairProducts(products, fallbackTotalCost: order.totalCost)
+        let resolvedTotalCost = resolvedOrderTotalCost(
+            currentTotalCost: order.totalCost,
+            products: repairedProducts
+        )
+
+        let repairedOrder = OrderModel(
+            id: order.id,
+            date: order.date,
+            type: order.type,
+            sum: order.sum,
+            cash: order.cash,
+            card: order.card,
+            totalCost: resolvedTotalCost,
+            note: order.note
+        )
+
+        return OrderSnapshotRepairResult(
+            order: repairedOrder,
+            products: repairedProducts,
+            didRepairProducts: repairedProducts != products,
+            didRepairOrder: !resolvedTotalCost.isApproximatelyEqual(to: order.totalCost)
+        )
+    }
+
+    func repairProducts(
+        _ products: [ProductOfOrderModel],
+        fallbackTotalCost: Double
+    ) -> [ProductOfOrderModel] {
+        guard !products.isEmpty else { return [] }
+
+        var repaired = products.map(repairDirectSnapshotGaps)
+
+        let missingIndices = repaired.indices.filter { index in
+            let product = repaired[index]
+            return product.quantity > 0
+                && product.costPrice.isApproximatelyZero
+                && product.costSum.isApproximatelyZero
+        }
+
+        guard !missingIndices.isEmpty else { return repaired }
+
+        let knownCost = repaired.reduce(0) { $0 + max($1.costSum, 0) }
+        let remainingCost = fallbackTotalCost - knownCost
+        guard remainingCost > 0 else { return repaired }
+
+        let weightedValues = missingIndices.map { index -> Double in
+            let product = repaired[index]
+            if !product.sum.isApproximatelyZero {
+                return product.sum
+            }
+            return Double(max(product.quantity, 1))
+        }
+        let totalWeight = weightedValues.reduce(0, +)
+        guard totalWeight > 0 else { return repaired }
+
+        var allocatedCost = 0.0
+        for (offset, index) in missingIndices.enumerated() {
+            let weight = weightedValues[offset]
+            let isLastItem = offset == missingIndices.count - 1
+            let costSum =
+                isLastItem
+                ? max(remainingCost - allocatedCost, 0)
+                : max(remainingCost * (weight / totalWeight), 0)
+
+            allocatedCost += costSum
+            repaired[index].costSum = costSum
+            repaired[index].costPrice =
+                repaired[index].quantity > 0
+                ? costSum / Double(repaired[index].quantity)
+                : 0
+        }
+
+        return repaired
+    }
+
+    func resolvedOrderTotalCost(
+        currentTotalCost: Double,
+        products: [ProductOfOrderModel]
+    ) -> Double {
+        let snapshotTotal = products.reduce(0) { $0 + max($1.costSum, 0) }
+        if snapshotTotal > 0 {
+            return snapshotTotal
+        }
+        return currentTotalCost
+    }
+
+    private func repairDirectSnapshotGaps(_ product: ProductOfOrderModel) -> ProductOfOrderModel {
+        var repaired = product
+
+        if repaired.quantity > 0 && repaired.costSum.isApproximatelyZero && repaired.costPrice > 0 {
+            repaired.costSum = repaired.costPrice * Double(repaired.quantity)
+        }
+
+        if repaired.quantity > 0 && repaired.costPrice.isApproximatelyZero && repaired.costSum > 0 {
+            repaired.costPrice = repaired.costSum / Double(repaired.quantity)
+        }
+
+        return repaired
+    }
+}
+
+private extension Double {
+    var isApproximatelyZero: Bool {
+        abs(self) < 0.000_1
+    }
+
+    func isApproximatelyEqual(to other: Double) -> Bool {
+        abs(self - other) < 0.000_1
+    }
+}

--- a/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/ViewModel/Products/ProductListViewModel.swift
+++ b/TrackMyCafe/View Layer/Flow/Orders/OrderDetails/ViewModel/Products/ProductListViewModel.swift
@@ -130,19 +130,11 @@ class ProductListViewModel: ProductListViewModelType, Loggable {
     }
 
     func getTotalAmount() -> Double {
-        var totalSum: Double = 0.0
-        for product in products {
-            totalSum += product.sum
-        }
-        return totalSum
+        orderMetrics().totalSale
     }
 
     func getTotalCostAmount() -> Double {
-        var totalCost: Double = 0.0
-        for product in products {
-            totalCost += product.costSum
-        }
-        return totalCost
+        orderMetrics().totalCost
     }
 
     func clearProducts() {
@@ -348,14 +340,7 @@ class ProductListViewModel: ProductListViewModelType, Loggable {
     // MARK: - Inventory Integration
 
     func validateStock(completion: @escaping ([StockWarning]) -> Void) {
-        let itemsToCheck = products.filter { $0.quantity > 0 }.map {
-            OrderItemModel(
-                productId: $0.productId,
-                quantity: $0.quantity,
-                salePrice: $0.price,
-                costPrice: $0.costPrice
-            )
-        }
+        let itemsToCheck = activeOrderItems()
 
         if itemsToCheck.isEmpty {
             completion([])
@@ -366,14 +351,7 @@ class ProductListViewModel: ProductListViewModelType, Loggable {
     }
 
     func deductStock(completion: @escaping (Bool) -> Void) {
-        let itemsToDeduct = products.filter { $0.quantity > 0 }.map {
-            OrderItemModel(
-                productId: $0.productId,
-                quantity: $0.quantity,
-                salePrice: $0.price,
-                costPrice: $0.costPrice
-            )
-        }
+        let itemsToDeduct = activeOrderItems()
 
         if itemsToDeduct.isEmpty {
             completion(true)
@@ -389,5 +367,15 @@ class ProductListViewModel: ProductListViewModelType, Loggable {
                 completion(false)
             }
         }
+    }
+
+    private func activeOrderItems() -> [OrderItemModel] {
+        products
+            .filter { $0.quantity > 0 }
+            .map(\.orderItemSnapshot)
+    }
+
+    private func orderMetrics() -> (totalSale: Double, totalCost: Double) {
+        costingService.calculateOrderMetrics(items: activeOrderItems())
     }
 }

--- a/TrackMyCafeTests/TrackMyCafeTests.swift
+++ b/TrackMyCafeTests/TrackMyCafeTests.swift
@@ -424,6 +424,130 @@ final class TrackMyCafeTests: XCTestCase {
         )
     }
 
+    func testOrderSnapshotRepairService_derivesMissingCostSumFromCostPrice() {
+        let service = OrderSnapshotRepairService()
+        let order = OrderModel(
+            id: "order-1",
+            date: makeDate(year: 2026, month: 6, day: 22),
+            type: "Hall",
+            sum: 90,
+            cash: 90,
+            card: 0,
+            totalCost: 30
+        )
+        let products = [
+            ProductOfOrderModel(
+                id: "item-1",
+                productId: "product-1",
+                orderId: "order-1",
+                date: order.date,
+                name: "Latte",
+                quantity: 3,
+                price: 30,
+                sum: 90,
+                costPrice: 10,
+                costSum: 0
+            )
+        ]
+
+        let result = service.repair(order: order, products: products)
+
+        XCTAssertTrue(result.didRepairProducts)
+        XCTAssertFalse(result.didRepairOrder)
+        XCTAssertEqual(result.products.first?.costSum, 30)
+        XCTAssertEqual(result.order.totalCost, 30)
+    }
+
+    func testOrderSnapshotRepairService_allocatesMissingItemCostsFromOrderTotalCost() {
+        let service = OrderSnapshotRepairService()
+        let order = OrderModel(
+            id: "order-2",
+            date: makeDate(year: 2026, month: 6, day: 22),
+            type: "Hall",
+            sum: 100,
+            cash: 100,
+            card: 0,
+            totalCost: 40
+        )
+        let products = [
+            ProductOfOrderModel(
+                id: "item-1",
+                productId: "product-1",
+                orderId: "order-2",
+                date: order.date,
+                name: "Espresso",
+                quantity: 1,
+                price: 40,
+                sum: 40
+            ),
+            ProductOfOrderModel(
+                id: "item-2",
+                productId: "product-2",
+                orderId: "order-2",
+                date: order.date,
+                name: "Latte",
+                quantity: 2,
+                price: 30,
+                sum: 60
+            ),
+        ]
+
+        let result = service.repair(order: order, products: products)
+
+        XCTAssertTrue(result.didRepairProducts)
+        XCTAssertFalse(result.didRepairOrder)
+        XCTAssertEqual(result.products[0].costSum, 16, accuracy: 0.0001)
+        XCTAssertEqual(result.products[0].costPrice, 16, accuracy: 0.0001)
+        XCTAssertEqual(result.products[1].costSum, 24, accuracy: 0.0001)
+        XCTAssertEqual(result.products[1].costPrice, 12, accuracy: 0.0001)
+        XCTAssertEqual(result.order.totalCost, 40, accuracy: 0.0001)
+    }
+
+    func testOrderSnapshotRepairService_backfillsMissingOrderTotalCostFromItems() {
+        let service = OrderSnapshotRepairService()
+        let order = OrderModel(
+            id: "order-3",
+            date: makeDate(year: 2026, month: 6, day: 22),
+            type: "Hall",
+            sum: 100,
+            cash: 50,
+            card: 50,
+            totalCost: 0
+        )
+        let products = [
+            ProductOfOrderModel(
+                id: "item-1",
+                productId: "product-1",
+                orderId: "order-3",
+                date: order.date,
+                name: "Flat White",
+                quantity: 2,
+                price: 25,
+                sum: 50,
+                costPrice: 7,
+                costSum: 14
+            ),
+            ProductOfOrderModel(
+                id: "item-2",
+                productId: "product-2",
+                orderId: "order-3",
+                date: order.date,
+                name: "Tea",
+                quantity: 2,
+                price: 25,
+                sum: 50,
+                costPrice: 3,
+                costSum: 6
+            ),
+        ]
+
+        let result = service.repair(order: order, products: products)
+
+        XCTAssertFalse(result.didRepairProducts)
+        XCTAssertTrue(result.didRepairOrder)
+        XCTAssertEqual(result.order.totalCost, 20, accuracy: 0.0001)
+    }
+
     private func makeDate(year: Int, month: Int, day: Int) -> Date {
         var components = DateComponents()
         components.year = year
@@ -547,6 +671,12 @@ private final class MockBalanceJournalService: BalanceJournalServiceProtocol {
     }
 
     func syncPurchase(previous: PurchaseModel?, current: PurchaseModel?) async throws -> Set<
+        BalanceScope
+    > {
+        []
+    }
+
+    func syncManual(sourceId: String, newEntries: [JournalEntryModel]) async throws -> Set<
         BalanceScope
     > {
         []


### PR DESCRIPTION
## Title

- feat(finance): lock historical COGS snapshot for orders

## Plan

- Align Order header + item-level snapshot with the target `#143` architecture.
- Ensure saved orders have stable `totalCost` and each item has stable `costPrice`.
- Add safe repair/backfill for legacy orders when loading.

## Code

- Add `OrderSnapshotRepairService` to repair missing COGS fields and persist repaired snapshots.
- Introduce `OrderItemModel` snapshot mapping from `ProductOfOrderModel`.
- Update order reads (`fetchOrders`, `fetchProduct(withOrderId:)`) to repair/backfill COGS and keep `OrderModel.totalCost` consistent.
- Update POS totals to compute via item snapshots (no UI changes).
- Add unit tests covering repair/backfill scenarios.

## Expected outcome

- Every saved order has a stable `totalCost`.
- Every saved item has a stable `costPrice`/`costSum`, representing COGS at sale time.
- Old orders load safely; missing snapshot data is repaired/backfilled.
- Cashier UX remains unchanged.

## Validation

- Unit tests: passed in Xcode.
- Manual QA: POS create/edit + stability across ingredient cost changes.

## References

- Closes #143
